### PR TITLE
Move 6to5 to peerDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,8 +4,10 @@
   "description": "6t05 module loader for webpack",
   "main": "index.js",
   "dependencies": {
-    "6to5": "^1.7.8",
     "loader-utils": "^0.2.4"
+  },
+  "peerDependencies": {
+    "6to5": "^1.7.8"
   },
   "devDependencies": {
     "mocha": "^1.21.4",


### PR DESCRIPTION
It makes sense so JS can use `require('6to5/polyfill')` (or `import '6to5/polyfill'`) without having to maintain a separate 6to5 dependency that gets out of sync in a project.
