### PR TITLE
Ignores node modules.

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,7 +2,6 @@ var loaderUtils = require('loader-utils'),
     to5 = require('6to5');
 
 module.exports = function (source) {
-
     var options = loaderUtils.parseQuery(this.query),
         result, code, map;
 
@@ -12,11 +11,18 @@ module.exports = function (source) {
 
     options.sourceMap = true;
     options.filename = loaderUtils.getRemainingRequest(this);
-    result = to5.transform(source, options);
 
-    code = result.code;
-    map = result.map;
-    map.sourcesContent = [source];
+    var nodeModule = options.filename.indexOf('node_modules') >= 0;
+
+    if (nodeModule) {
+        code = source;
+    } else {
+        result = to5.transform(source, options);
+
+        code = result.code;
+        map = result.map;
+        map.sourcesContent = [source];
+    }
 
     this.callback(null, code, map);
 };


### PR DESCRIPTION
This is an example PR that resolves #4.

The problem was that I was compiling all of the node modules. This particular project has lots of node module dependencies, and it was _seriously_ slowing things down.

With this fix, my build time went from 30secs to 3secs.

Props to @thejameskyle for sharing [this comment](https://github.com/6to5/6to5/issues/144#issuecomment-62532353) with me.
