### PR TITLE
Merge new sourcemap with existing one, if any

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,3 +1,4 @@
+var sourceMap = require('source-map');
 var loaderUtils = require('loader-utils'),
     babel = require('babel-core'),
     toBoolean = function (val) {
@@ -6,7 +7,7 @@ var loaderUtils = require('loader-utils'),
         return val;
     };
 
-module.exports = function (source) {
+module.exports = function (source, inputMap) {
 
     var options = loaderUtils.parseQuery(this.query),
         result, code, map;
@@ -29,6 +30,21 @@ module.exports = function (source) {
 
     map = result.map;
     if (map) {
+
+        if (inputMap) {
+            map.sources[0] = inputMap.file;
+
+            var inputMapConsumer = new sourceMap.SourceMapConsumer(inputMap);
+            var outputMapConsumer = new sourceMap.SourceMapConsumer(map);
+            var outputMapGenerator = sourceMap.SourceMapGenerator.fromSourceMap(outputMapConsumer);
+            outputMapGenerator.applySourceMap(inputMapConsumer);
+            var mergedMap = outputMapGenerator.toJSON();
+
+            mergedMap.sources = map.sources
+            mergedMap.file = map.file;
+            map = mergedMap;
+        }
+
         map.sourcesContent = [source];
     }
 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "babel module loader for webpack",
   "main": "index.js",
   "dependencies": {
-    "loader-utils": "^0.2.5"
+    "loader-utils": "^0.2.5",
+    "source-map": "^0.4.1"
   },
   "peerDependencies": {
     "babel-core": "^4.0.0",


### PR DESCRIPTION
If the input code fed to Babel was preprocessed before (by a loader earlier in the chain) and a source map was produced, that source map used to be discarded.  With this change any such source map is correctly merged with the source map produced by Babel.