### PR TITLE
Support an optional 'cacheDirectory' param to cache babel loader results.

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,13 @@ loaders: [
 
 See the `babel` [options](http://babeljs.io/docs/usage/options/)
 
+This loader also supports the following loader-specific option:
+
+* `cacheDirectory`: When set, the given directory will be used to cache the results of the loader.
+  Future webpack builds will attempt to read from the cache to avoid needing to run the potentially
+  expensive Babel recompilation process on each run. A value of `true` will cause the loader to
+  use the default OS temporary file directory.
+
 ## License
 
 MIT © Luis Couto

--- a/index.js
+++ b/index.js
@@ -1,5 +1,11 @@
 var loaderUtils = require('loader-utils'),
     babel = require('babel-core'),
+    crypto = require('crypto'),
+    fs = require('fs'),
+    path = require('path'),
+    os = require('os'),
+    zlib = require('zlib'),
+    version = require('./package').version,
     toBoolean = function (val) {
         if (val === 'true') { return true; }
         if (val === 'false') { return false; }
@@ -9,7 +15,8 @@ var loaderUtils = require('loader-utils'),
 module.exports = function (source, inputSourceMap) {
 
     var options = loaderUtils.parseQuery(this.query),
-        result, code, map;
+        callback = this.async(),
+        result, cacheDirectory;
 
     if (this.cacheable) {
         this.cacheable();
@@ -25,14 +32,94 @@ module.exports = function (source, inputSourceMap) {
     options.inputSourceMap = inputSourceMap;
     options.filename = loaderUtils.getRemainingRequest(this);
 
-    result = babel.transform(source, options);
-    code = result.code;
+    cacheDirectory = options.cacheDirectory;
+    delete options.cacheDirectory;
 
-    map = result.map;
+    if (cacheDirectory === true) cacheDirectory = os.tmpdir();
+
+    if (cacheDirectory){
+        cachedTranspile(cacheDirectory, source, options, onResult);
+    } else {
+        onResult(null, transpile(source, options));
+    }
+
+    function onResult(err, result){
+        if (err) return callback(err);
+
+        callback(err, err ? null : result.code, err ? null : result.map);
+    }
+};
+
+function transpile(source, options){
+    var result = babel.transform(source, options);
+
+    var code = result.code;
+    var map = result.map;
     if (map) {
         map.sourcesContent = [source];
     }
 
-    this.callback(null, code, map);
+    return {
+        code: code,
+        map: map
+    };
+}
 
-};
+function cachedTranspile(cacheDirectory, source, options, callback){
+    var cacheFile = path.join(cacheDirectory, buildCachePath(cacheDirectory, source, options));
+
+    readCache(cacheFile, function(err, result){
+        if (err){
+            try {
+                result = transpile(source, options);
+            } catch (e){
+                return callback(e);
+            }
+
+            writeCache(cacheFile, result, function(err){
+                callback(err, result);
+            });
+        } else {
+            callback(null, result);
+        }
+    });
+}
+
+function readCache(cacheFile, callback){
+    fs.readFile(cacheFile, function(err, data){
+        if (err) return callback(err);
+
+        zlib.gunzip(data, function(err, content){
+            if (err) return callback(err);
+
+            try {
+                content = JSON.parse(content);
+            } catch (e){
+                return callback(e);
+            }
+
+            callback(null, content);
+        });
+    });
+}
+
+function writeCache(cacheFile, result, callback){
+    var content = JSON.stringify(result);
+
+    zlib.gzip(content, function(err, data){
+        if (err) return callback(err);
+
+        fs.writeFile(cacheFile, data, callback);
+    });
+}
+
+function buildCachePath(dir, source, options){
+    var hash = crypto.createHash('SHA1');
+    hash.end(JSON.stringify({
+        loaderVersion: version,
+        babelVersion: babel.version,
+        source: source,
+        options: options
+    }));
+    return 'babel-loader-cache-' + hash.read().toString('hex') + '.json.gzip';
+}


### PR DESCRIPTION
Here's a first pass at my solution for #34. Added an explicit cache param and `zlib` usage to keep the size of the cache a bit more reasonable.

Our codebase is pretty big, using this cache, I see:

* Transpiling both source and tests: `130s` with cold cache, `40s` with cache, 3.25x speedup
* Transpiling only source `45s` with cold cache, `22s` with cache, 2x speedup

Those numbers definitely make it clear to me that having the cache will be a big help to webpack initial start time.