### PR TITLE
Move babel-core to devDependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 ## Install
 
 ```
-$ npm install --save-dev babel-loader
+$ npm install --save-dev babel-loader babel-core
 ```
 
 ## Usage

--- a/index.js
+++ b/index.js
@@ -1,5 +1,4 @@
 var loaderUtils = require('loader-utils'),
-    babel = require('babel-core'),
     crypto = require('crypto'),
     fs = require('fs'),
     path = require('path'),
@@ -11,6 +10,21 @@ var loaderUtils = require('loader-utils'),
         if (val === 'false') { return false; }
         return val;
     };
+
+try {
+    var babel = require('babel-core');
+
+} catch(err) {
+    if (err.code != 'MODULE_NOT_FOUND') {
+        throw err;
+    }
+
+    console.error(
+        'Error: babel-core package is not installed, please run:\n\n' +
+        '    npm install --save-dev babel-core\n'
+    );
+    process.exit(1);
+}
 
 module.exports = function (source, inputSourceMap) {
 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,6 @@
   "description": "babel module loader for webpack",
   "main": "index.js",
   "dependencies": {
-    "babel-core": "^5.0.0",
     "loader-utils": "^0.2.5"
   },
   "peerDependencies": {
@@ -12,6 +11,7 @@
     "webpack": "*"
   },
   "devDependencies": {
+    "babel-core": "^5.1.13",
     "mocha": "^2.0.1",
     "mocha-loader": "^0.7.0",
     "should": "^4.3.1",


### PR DESCRIPTION
Prevent `TypeError: Transformer PLUGIN NAME is resolving to a different Babel version to what is doing the actual transformation…` errors by removing `babel-core` from `dependencies`.

See: https://github.com/babel/babel/issues/1244