### PR TITLE
Remove babel-core from dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 ## Installation
 
 ```bash
-npm install babel-loader --save-dev
+npm install babel-loader babel-core --save-dev
 ```
 
 __Note:__ [npm](https://npmjs.com) will deprecate [peerDependencies](https://github.com/npm/npm/issues/6565) on the next major release, so required dependencies like babel-core and webpack will have to be installed manually.

--- a/index.js
+++ b/index.js
@@ -1,8 +1,22 @@
 var assign = require('object-assign');
-var babel = require('babel-core');
 var cache = require('./lib/fs-cache.js');
 var loaderUtils = require('loader-utils');
 var pkg = require('./package.json');
+
+try {
+  var babel = require('babel-core');
+
+} catch(err) {
+  if (err.code != 'MODULE_NOT_FOUND') {
+    throw err;
+  }
+
+  console.error(
+    'Error: babel-core package is not installed, please run:\n\n' +
+    '    npm install --save-dev babel-core\n'
+  );
+  process.exit(1);
+}
 
 var transpile = function(source, options) {
   var result = babel.transform(source, options);

--- a/package.json
+++ b/package.json
@@ -4,7 +4,6 @@
   "description": "babel module loader for webpack",
   "main": "index.js",
   "dependencies": {
-    "babel-core": "5.0.0",
     "object-assign": "^2.0.0",
     "loader-utils": "^0.2.6"
   },


### PR DESCRIPTION
Prevent `TypeError: Transformer PLUGIN NAME is resolving to a different Babel version to what is doing the actual transformation…` errors by removing `babel-core` from `dependencies`.

See: https://github.com/babel/babel/issues/1244