### PR TITLE
Fix reading cache function to callback a proper result

### DIFF
--- a/lib/fs-cache.js
+++ b/lib/fs-cache.js
@@ -37,7 +37,7 @@ var read = function(filename, callback) {
         return callback(e);
       }
 
-      return callback(null, content);
+      return callback(null, result);
     });
   });
 };


### PR DESCRIPTION
hi.

to solve `Module build failed: Error: Final loader didn't return a Buffer or String` which is constantly appears after `@5.1` update.

`content` is a raw file buffer, so `.code` from it is `undefined`.