### PR TITLE
Enter async mode only when necessary

### DIFF
--- a/index.js
+++ b/index.js
@@ -22,7 +22,6 @@ var transpile = function(source, options) {
 };
 
 module.exports = function(source, inputSourceMap) {
-  var callback = this.async();
   var result = {};
   // Handle options
   var defaultOptions = {
@@ -50,6 +49,7 @@ module.exports = function(source, inputSourceMap) {
   this.cacheable();
 
   if (cacheDirectory) {
+    var callback = this.async();
     return cache({
       directory: cacheDirectory,
       identifier: cacheIdentifier,
@@ -63,6 +63,6 @@ module.exports = function(source, inputSourceMap) {
   }
 
   result = transpile(source, options);
-  return callback(null, result.code, result.map);
+  this.callback(null, result.code, result.map);
 
 };


### PR DESCRIPTION
Hi,

Ever since babel-loader introduced caching we can't use it anymore together with [enhanced-require](https://github.com/webpack/enhanced-require) as that doesn't support async callbacks in loaders.

This change restores enhanced-require compatibility as long as the cacheDirectory option isn't used.

(It would be possible to implement caching synchronously but I suppose there are performance concerns. We don't need caching when using enhanced-require so I left caching to be async.)
