### PR TITLE
Fix for 'Module build failed: TypeError: Object.keys called on non-object'

### DIFF
--- a/index.js
+++ b/index.js
@@ -35,7 +35,7 @@ module.exports = function(source, inputSourceMap) {
       babelrc: babelrc || '',
     }),
   };
-  var globalOptions = this.options.babel;
+  var globalOptions = this.options.babel || {};
   var loaderOptions = loaderUtils.parseQuery(this.query);
   var options = assign({}, defaultOptions, globalOptions, loaderOptions);
 


### PR DESCRIPTION
### Problem
I was running webpack from gulp and got:
```
Module build failed: TypeError: Object.keys called on non-object 
  at keys (native)
  at assign (eval at <anonymous> (../node_modules/gulp-traceur/node_modules/traceur/src/node/traceur.js:24:17), <anonymous>:2276:19)
  at Object.module.exports (.../node_modules/babel-loader/index.js:40:17)
```
### Cause

The object-assign package returns the 'native' Object.assign' when it exists.
When using traceur@0.0.58  it creates an Object.assign implementation using Object.keys which fails with non-object values.

A workaround was to add `require('babel-loader');` before `var traceur = require('gulp-traceur');` in my gulpfile.