### PR TITLE
Don't override existing items in sourcesContent if any

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,7 +13,7 @@ var transpile = function(source, options) {
   var code = result.code;
   var map = result.map;
 
-  if (map) {
+  if (map && (!map.sourcesContent || !map.sourcesContent.length)) {
     map.sourcesContent = [source];
   }
 


### PR DESCRIPTION
The problem appears when babel-loader is used in a chain with another loader, e.g. [awesome-typescript-loader](https://github.com/s-panferov/awesome-typescript-loader) which provides existing source map with own sourcesContent.

In this case we need to leave the items in the array as-is. I've tested it locally, it worked.