### PR TITLE
Remove `babel-core` from devDependencies and peerDependencies.

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,6 @@
 npm install babel-loader --save-dev
 ```
 
-__Note:__ [npm](https://npmjs.com) will deprecate [auto-installing of peerDependencies](https://github.com/npm/npm/issues/6565) on the next major release, so required peer dependencies like babel-core and webpack will have to be listed explicitly in your `package.json`.
-
 ## Usage
 
 [Documentation: Using loaders](http://webpack.github.io/docs/using-loaders.html)

--- a/package.json
+++ b/package.json
@@ -9,11 +9,9 @@
     "object-assign": "^3.0.0"
   },
   "peerDependencies": {
-    "babel-core": "*",
     "webpack": "*"
   },
   "devDependencies": {
-    "babel-core": "^5.5.8",
     "expect.js": "^0.3.1",
     "istanbul": "^0.3.15",
     "jscs": "^1.13.1",


### PR DESCRIPTION
Just having it as a dependency is enough; [grunt-babel](https://github.com/babel/grunt-babel) and [gulp-babel](https://github.com/babel/gulp-babel) also do this.

Also fixes #47.