### PR TITLE
Pass true file names to Babel

### DIFF
--- a/index.js
+++ b/index.js
@@ -26,9 +26,11 @@ var transpile = function(source, options) {
 module.exports = function(source, inputSourceMap) {
   var result = {};
   // Handle options
+  var webpackRemainingChain = loaderUtils.getRemainingRequest(this).split('!');
+  var filename = webpackRemainingChain[webpackRemainingChain.length - 1];
   var defaultOptions = {
     inputSourceMap: inputSourceMap,
-    filename: loaderUtils.getRemainingRequest(this),
+    filename: filename,
     cacheIdentifier: JSON.stringify({
       'babel-loader': pkg.version,
       'babel-core': babel.version,


### PR DESCRIPTION
Fixes #106. Certain Babel plugins don't know what to do with a Webpack URL.

No unit tests for this PR, unfortunately, couldn't get them running on Windows.