### PR TITLE
Include BABEL_ENV || NODE_ENV in cacheIdentifier

### DIFF
--- a/index.js
+++ b/index.js
@@ -33,6 +33,7 @@ module.exports = function(source, inputSourceMap) {
       'babel-loader': pkg.version,
       'babel-core': babel.version,
       babelrc: babelrc || '',
+      env: process.env.BABEL_ENV || process.env.NODE_ENV,
     }),
   };
   var globalOptions = this.options.babel || {};


### PR DESCRIPTION
babel configs can differ based on BABEL_ENV and NODE_ENV, so cache identifier should be different. This may have been the thing that caused #112