### PR TITLE
Change loader: babel-loader => loader: babel

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ module: {
 
   This loader also supports the following loader-specific option:
 
-  * `cacheDirectory`: When set, the given directory will be used to cache the results of the loader. Future webpack builds will attempt to read from the cache to avoid needing to run the potentially expensive Babel recompilation process on each run. The default value (`loader: 'babel-loader?cacheDirectory'`) will cause the loader to use the default OS temporary file directory.
+  * `cacheDirectory`: When set, the given directory will be used to cache the results of the loader. Future webpack builds will attempt to read from the cache to avoid needing to run the potentially expensive Babel recompilation process on each run. The default value (`loader: 'babel?cacheDirectory'`) will cause the loader to use the default OS temporary file directory.
 
   * `cacheIdentifier`: When set, it will add the given identifier to the cached files. This can be used to force cache busting if the identifier changes. By default the identifier is composed by the babel-core's version, the babel-loader's version and the .babelrc file if it exists.
 
@@ -142,7 +142,7 @@ loaders: [
   {
     test: /\.jsx?$/,
     exclude: /(node_modules|bower_components)/,
-    loader: 'babel-loader?cacheDirectory'
+    loader: 'babel?cacheDirectory'
   }
 ]
 ```
@@ -156,7 +156,7 @@ loaders: [
   {
     test: /\.jsx?$/,
     exclude: /(node_modules|bower_components)/,
-    loader: 'babel-loader',
+    loader: 'babel',
     query: {
       cacheDirectory: true
     }

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ module: {
     {
       test: /\.jsx?$/,
       exclude: /(node_modules|bower_components)/,
-      loader: 'babel'
+      loader: 'babel' // 'babel-loader' is also a legal name to reference
     }
   ]
 }


### PR DESCRIPTION
Hello,

There are some places in README that say  _loader: 'babel'_ and some of them  _loader: 'babel-loader'_.
I think it should be changed to be the same everywhere.
Please let me know if this makes sense.

Thanks