### PR TITLE
Remove `main` field from package.json and add `files` field instead

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,10 @@
   "name": "babel-loader",
   "version": "6.0.0",
   "description": "babel module loader for webpack",
-  "main": "index.js",
+  "files": [
+    "index.js",
+    "lib"
+  ],
   "dependencies": {
     "loader-utils": "^0.2.11",
     "object-assign": "^4.0.1"


### PR DESCRIPTION
* I removed [`main`](https://docs.npmjs.com/files/package.json#main) field from [package.json](https://github.com/babel/babel-loader/blob/ff3bc7ada2ffa81a9d666789c4f2cb1d06f2c0c3/package.json).
  * It's not needed since the package entry point is `index.js` by default.
* I added [`files`](https://docs.npmjs.com/files/package.json#files) field to package.json.

This change reduces the npm package size:

```sh
# the latest version on npm
$ npm install babel-loader@6.0.0
$ du -sh node_modules
> 820K	node_modules

# this pull request
$ npm install babel/babel-loader#c099fd8daabb6844c26e8c1655e204a5d64dbd04
$ du -sh node_modules
> 756K	node_modules
```
