### PR TITLE
fix cache directory setting in the test

### DIFF
--- a/test/cache.test.js
+++ b/test/cache.test.js
@@ -10,8 +10,7 @@ var rimraf = require('rimraf');
 var webpack = require('webpack');
 
 describe('Filesystem Cache', function() {
-
-  this.timeout(3000);
+  this.timeout(15000);
 
   var cacheDir = path.resolve(__dirname, 'output/cache/cachefiles');
   var outputDir = path.resolve(__dirname, './output/cache/');

--- a/test/cache.test.js
+++ b/test/cache.test.js
@@ -81,7 +81,7 @@ describe('Filesystem Cache', function() {
             loader: babelLoader,
             exclude: /node_modules/,
             query: {
-              cacheDirectory: cacheDir,
+              cacheDirectory: true,
               presets: ['es2015'],
             },
           },
@@ -93,7 +93,6 @@ describe('Filesystem Cache', function() {
       expect(err).to.be(null);
 
       fs.readdir(os.tmpdir(), function(err, files) {
-
         files = files.filter(function(file) {
           return /\b[0-9a-f]{5,40}\.json\.gzip\b/.test(file);
         });


### PR DESCRIPTION
In this case babel-loader should use OS's temporary directory as `cacheDirectory`, but currently uses `cacheDir` instead. https://github.com/babel/babel-loader/blob/a6f3fc00eb53c302187322ca61d1eebcaa075044/test/cache.test.js#L84
