### PR TITLE
Set source file name relative to options.sourceRoot

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,6 +7,7 @@ var cache = require('./lib/fs-cache.js');
 var resolveRc = require('./lib/resolve-rc.js');
 var pkg = require('./package.json');
 var babelrc = resolveRc(process.cwd());
+var path = require('path');
 
 var transpile = function(source, options) {
   var result = babel.transform(source, options);
@@ -28,6 +29,7 @@ module.exports = function(source, inputSourceMap) {
   // Handle options
   var defaultOptions = {
     inputSourceMap: inputSourceMap,
+    sourceRoot: process.cwd(),
     filename: loaderUtils.getRemainingRequest(this),
     cacheIdentifier: JSON.stringify({
       'babel-loader': pkg.version,
@@ -41,6 +43,13 @@ module.exports = function(source, inputSourceMap) {
 
   if (options.sourceMap === undefined) {
     options.sourceMap = this.sourceMap;
+  }
+
+  if (options.sourceFileName === undefined) {
+    options.sourceFileName = path.relative(
+        options.sourceRoot,
+        options.filename
+    );
   }
 
   var cacheDirectory = options.cacheDirectory;


### PR DESCRIPTION
Fixes #137 by setting `options.sourceFileName`. If I understand correct, it's a basename by default (see Babel code here: https://github.com/chalbert/babel/blob/9d43776fbebf862e56d059dff117e55823f662b5/packages/babel-core/src/transformation/file/index.js#L161)