### PR TITLE
fix removed dependency note for babel-runtime usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ module: {
 
   See the [docs](http://babeljs.io/docs/plugins/transform-runtime/) for more information.
 
-  **NOTE:** You must run `npm install babel-plugin-transform-runtime --save` to include this in your project.
+  __Note:__ You must run `npm install babel-runtime babel-plugin-transform-runtime --save` to include this in your project.
 
 ```javascript
 loaders: [


### PR DESCRIPTION
Per @Dashed comment https://github.com/babel/babel-loader/pull/156#issuecomment-158935495, I removed too much from the docs update in #156. 

This PR adds the `babel-runtime` dependency back as an explicit package that is to be installed.