### PR TITLE
Remove webpack peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,8 +11,7 @@
     "object-assign": "^4.0.1"
   },
   "peerDependencies": {
-    "babel-core": "^6.0.0",
-    "webpack": "*"
+    "babel-core": "^6.0.0"
   },
   "devDependencies": {
     "babel-core": "^6.0.0",


### PR DESCRIPTION
As far as  I can tell, it doesn't look like babel-loader uses webpack directly, nor does it depend on a specific version of webpack to work, so I'm not sure there's any reason to explicitly list the peer dependency, which causes npm 2 users to have to download and install webpack locally for every project that uses babel-loader.

Even if you'd like to keep the peer dependency, I think the `*` should be made a specific version since things will potentially break if/when webpack 2 moves out of beta (you don't want to say 'any version will do' if the API for webpack 1 and 2 are different, although I have no idea if they are).