### PR TITLE
updates docs re: transform-runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,9 +176,9 @@ loaders: [
 ```
 
 
-### custom polyfills (e.g. Promise library)
+### transform-runtime & custom polyfills (e.g. Promise library)
 
-Since Babel includes a polyfill that includes a custom [regenerator runtime](https://github.com/facebook/regenerator/blob/master/runtime.js) and [core.js](https://github.com/zloirock/core-js), the following usual shimming method using `webpack.ProvidePlugin` will not work:
+Since Babel 6 (w/ [babel-plugin-transform-runtime](https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-runtime)) includes a polyfill that includes a custom [regenerator runtime](https://github.com/facebook/regenerator/blob/master/runtime.js) and [core.js](https://github.com/zloirock/core-js), the following usual shimming method using `webpack.ProvidePlugin` will not work:
 
 ```javascript
 // ...

--- a/README.md
+++ b/README.md
@@ -123,6 +123,52 @@ loaders: [
 ]
 ```
 
+#### **NOTE:** transform-runtime & custom polyfills (e.g. Promise library)
+
+Since [babel-plugin-transform-runtime](https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-runtime) includes a polyfill that includes a custom [regenerator runtime](https://github.com/facebook/regenerator/blob/master/runtime.js) and [core.js](https://github.com/zloirock/core-js), the following usual shimming method using `webpack.ProvidePlugin` will not work:
+
+```javascript
+// ...
+        new webpack.ProvidePlugin({
+            'Promise': 'bluebird'
+        }),
+// ...
+```
+
+The following approach will not work either:
+
+```javascript
+require('babel-runtime/core-js/promise').default = require('bluebird');
+
+var promise = new Promise;
+```
+
+which outputs to (using `runtime`):
+
+```javascript
+'use strict';
+
+var _Promise = require('babel-runtime/core-js/promise')['default'];
+
+require('babel-runtime/core-js/promise')['default'] = require('bluebird');
+
+var promise = new _Promise();
+```
+
+The previous `Promise` library is referenced and used before it is overridden.
+
+One approach is to have a "bootstrap" step in your application that would first override the default globals before your application:
+
+```javascript
+// bootstrap.js
+
+require('babel-runtime/core-js/promise').default = require('bluebird');
+
+// ...
+
+require('./app');
+```
+
 ### using `cacheDirectory` fails with ENOENT Error
 
 If using cacheDirectory results in an error similar to the following:
@@ -175,51 +221,5 @@ loaders: [
 ]
 ```
 
-
-### transform-runtime & custom polyfills (e.g. Promise library)
-
-Since Babel 6 (w/ [babel-plugin-transform-runtime](https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-runtime)) includes a polyfill that includes a custom [regenerator runtime](https://github.com/facebook/regenerator/blob/master/runtime.js) and [core.js](https://github.com/zloirock/core-js), the following usual shimming method using `webpack.ProvidePlugin` will not work:
-
-```javascript
-// ...
-        new webpack.ProvidePlugin({
-            'Promise': 'bluebird'
-        }),
-// ...
-```
-
-The following approach will not work either:
-
-```javascript
-require('babel-runtime/core-js/promise').default = require('bluebird');
-
-var promise = new Promise;
-```
-
-which outputs to (using `runtime`):
-
-```javascript
-'use strict';
-
-var _Promise = require('babel-runtime/core-js/promise')['default'];
-
-require('babel-runtime/core-js/promise')['default'] = require('bluebird');
-
-var promise = new _Promise();
-```
-
-The previous `Promise` library is referenced and used before it is overridden.
-
-One approach is to have a "bootstrap" step in your application that would first override the default globals before your application:
-
-```javascript
-// bootstrap.js
-
-require('babel-runtime/core-js/promise').default = require('bluebird');
-
-// ...
-
-require('./app');
-```
 
 ## [License](http://couto.mit-license.org/)


### PR DESCRIPTION
babel 6 does not include the transform-runtime by default so the webpack.ProvidePlugin polyfill should work 
