### PR TITLE
Update peerDependencies to include Webpack 2

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   },
   "peerDependencies": {
     "babel-core": "^6.0.0",
-    "webpack": "^1.0.0"
+    "webpack": "^1.0.0 || 2.0.6-beta || ^2.0.0"
   },
   "devDependencies": {
     "expect.js": "^0.3.1",


### PR DESCRIPTION
Webpack 2 does not seem to have changes breaking this loader. In this PR, we explicitly enable the latest beta (since we have to specify exact prerelease versions in semver), as well as the stable 2.x when it comes out.