### PR TITLE
Permit webpack@2.0.7-beta

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   },
   "peerDependencies": {
     "babel-core": "^6.0.0",
-    "webpack": "^1.0.0 || 2.0.6-beta || ^2.0.0"
+    "webpack": "1 - 2 || 2.0.6-beta || 2.0.7-beta"
   },
   "devDependencies": {
     "expect.js": "^0.3.1",


### PR DESCRIPTION
Perhaps `2.0.0-beta`, `2.0.1-beta`, `2.0.2-beta`, `2.0.4-beta` and `2.0.5-beta` should also be permitted. Note that `2.0.3-beta` was unpublished or never existed.

Here is a before and after from [semver.npmjs.com](http://semver.npmjs.com/):

| Before | After |
|--------|-------|
| ![screen shot 2016-02-18 at 3 13 55 am](https://cloud.githubusercontent.com/assets/13998/13117947/b809bb32-d5ed-11e5-9a7c-005e337c0a46.png) | ![screen shot 2016-02-18 at 3 13 06 am](https://cloud.githubusercontent.com/assets/13998/13117911/94f6f588-d5ed-11e5-810f-d4eb283d72f1.png) |

It escapes me [and others](https://github.com/webpack/webpack/issues/2004) why `2.0.1-beta` wasn't released as `2.0.0-beta1` or `2.0.0-beta.1` and so on and so forth.