### PR TITLE
Remove 'react' preset

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ module: {
       exclude: /(node_modules|bower_components)/,
       loader: 'babel', // 'babel-loader' is also a legal name to reference
       query: {
-        presets: ['react', 'es2015']
+        presets: ['es2015']
       }
     }
   ]
@@ -48,7 +48,7 @@ module: {
     {
       test: /\.jsx?$/,
       exclude: /(node_modules|bower_components)/,
-      loader: 'babel?presets[]=react,presets[]=es2015'
+      loader: 'babel?presets[]=es2015'
     }
   ]
 }
@@ -64,7 +64,7 @@ module: {
       exclude: /(node_modules|bower_components)/,
       loader: 'babel',
       query: {
-        presets: ['react', 'es2015']
+        presets: ['es2015']
       }
     }
   ]
@@ -116,7 +116,7 @@ loaders: [
     exclude: /(node_modules|bower_components)/,
     loader: 'babel',
     query: {
-      presets: ['react', 'es2015'],
+      presets: ['es2015'],
       plugins: ['transform-runtime']
     }
   }


### PR DESCRIPTION
Remove the 'react' preset from the loader query.

It's not needed for the babel loader to work, and it doesn't get installed when the above ``npm install`` command is run. This could bite people that are not using React and just want the babel loader to work.