### PR TITLE
fix(symlinked resources): configure the babelWD

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,4 +14,4 @@
 
   If, however, you want to ensure that you're following the node style guide, you can use [JSCS](https://github.com/jscs-dev/node-jscs). The rules are already set on the [.jscsrc](https://github.com/babel/babel-loader/blob/master/.jscsrc) file and there's most likely some [package](http://jscs.info/overview.html#friendly-packages) to your editor already.
 
-  Documentation, wether in the state of JavaDoc or simple line comments are always welcome.
+  Documentation, whether in the state of JavaDoc or simple line comments are always welcome.

--- a/index.js
+++ b/index.js
@@ -36,6 +36,10 @@ module.exports = function(source, inputSourceMap) {
   var globalOptions = this.options.babel || {};
   var loaderOptions = loaderUtils.parseQuery(this.query);
   var userOptions = assign({}, globalOptions, loaderOptions);
+  var babelrc = exists(userOptions.babelrc) ?
+    read(userOptions.babelrc) :
+    resolveRc(process.cwd());
+  var babelrcOpts = JSON.parse(babelrc || '{}');
   var defaultOptions = {
     inputSourceMap: inputSourceMap,
     sourceRoot: process.cwd(),
@@ -43,14 +47,14 @@ module.exports = function(source, inputSourceMap) {
     cacheIdentifier: JSON.stringify({
       'babel-loader': pkg.version,
       'babel-core': babel.version,
-      babelrc: exists(userOptions.babelrc) ?
-          read(userOptions.babelrc) :
-          resolveRc(process.cwd()),
+      babelrc: babelrc,
       env: process.env.BABEL_ENV || process.env.NODE_ENV,
     }),
   };
 
-  var options = assign({}, defaultOptions, userOptions);
+  babelrcOpts.babelWD = process.cwd();
+
+  var options = assign({}, defaultOptions, babelrcOpts, userOptions);
 
   if (userOptions.sourceMap === undefined) {
     options.sourceMap = this.sourceMap;


### PR DESCRIPTION
By specifying the `babelWD` as being the process cwd we allow preset and
plugin resolution to occur relative to the directory where webpack is
running. This should resolve issues where presets and plugins could not
be resolved.

closes: #166, #179 
