### PR TITLE
Update README docs for cacheDirectory's actual behaviour

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ module: {
 }
   ```
 
-  or by using the query property:
+  or by using the [query property](https://webpack.github.io/docs/using-loaders.html#query-parameters):
 
   ```javascript
 module: {
@@ -73,7 +73,7 @@ module: {
 
   This loader also supports the following loader-specific option:
 
-  * `cacheDirectory`: Default `false`. When set, the given directory will be used to cache the results of the loader. Future webpack builds will attempt to read from the cache to avoid needing to run the potentially expensive Babel recompilation process on each run. If the value is blank (`loader: 'babel-loader?cacheDirectory'`) the loader will use the default OS temporary file directory.
+  * `cacheDirectory`: Default `false`. When set, the given directory will be used to cache the results of the loader. Future webpack builds will attempt to read from the cache to avoid needing to run the potentially expensive Babel recompilation process on each run. If the value is blank (`loader: 'babel-loader?cacheDirectory'`) or true (`loader: babel-loader?cacheDirectory=true` or using the query syntax), the loader will use the default OS temporary file directory.
 
   * `cacheIdentifier`: Default is a string composed by the babel-core's version, the babel-loader's version and the contents of .babelrc file if it exists. This can set to a custom value to force cache busting if the identifier changes.
 
@@ -118,58 +118,6 @@ loaders: [
     query: {
       presets: ['es2015'],
       plugins: ['transform-runtime']
-    }
-  }
-]
-```
-
-### using `cacheDirectory` fails with ENOENT Error
-
-If using cacheDirectory results in an error similar to the following:
-
-```
-ERROR in ./frontend/src/main.jsx
-Module build failed: Error: ENOENT, open 'true/350c59cae6b7bce3bb58c8240147581bfdc9cccc.json.gzip'
- @ multi app
-```
-(notice the `true/` in the filepath)
-
-That means that most likely, you're not setting the options correctly, and you're doing something similar to:
-
-```javascript
-loaders: [
-  {
-    test: /\.jsx?$/,
-    exclude: /(node_modules|bower_components)/,
-    loader: 'babel?cacheDirectory=true'
-  }
-]
-```
-
-That's not the correct way of setting boolean values. You should do instead:
-
-```javascript
-loaders: [
-  {
-    test: /\.jsx?$/,
-    exclude: /(node_modules|bower_components)/,
-    loader: 'babel?cacheDirectory'
-  }
-]
-```
-
-or use the [query](https://webpack.github.io/docs/using-loaders.html#query-parameters) property:
-
-```javascript
-loaders: [
-  // the optional 'runtime' transformer tells babel to require the runtime
-  // instead of inlining it.
-  {
-    test: /\.jsx?$/,
-    exclude: /(node_modules|bower_components)/,
-    loader: 'babel',
-    query: {
-      cacheDirectory: true
     }
   }
 ]


### PR DESCRIPTION
I'm not sure exactly when the changes were made to fs-cache that outdated the current docs, but given [this line in fs-cache](https://github.com/babel/babel-loader/blob/master/lib/fs-cache.js#L127), it correctly uses the OS's temp dir regardless of if the query param is `?cacheDirectory` or `?cacheDirectory=true` (and, in fact, using the query property syntax results in the same behaviour as `?cacheDirectory=true`).
