### PR TITLE
pass metadata form babel to a webpack plugin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules
 test/output
 coverage
 *.log
+.idea/*

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,7 @@ before_install:
   - npm --version
 before_script:
   - 'if [ "$WEBPACK_VERSION" ]; then npm install webpack@^$WEBPACK_VERSION; fi'
+  - npm install babel-core babel-preset-es2015
 script:
   - npm run travis
 after_success:

--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ module: {
 
   See the [docs](http://babeljs.io/docs/plugins/transform-runtime/) for more information.
 
-  **NOTE:** You must run `npm install babel-plugin-transform-runtime --save-dev` to include this in your project.
+  **NOTE:** You must run `npm install babel-plugin-transform-runtime --save-dev` to include this in your project and `babel-runtime` itelf as a dependency with `npm install babel-runtime --save`.
 
 ```javascript
 loaders: [

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# babel-loader [![Build Status](https://travis-ci.org/babel/babel-loader.svg?branch=master)](https://travis-ci.org/babel/babel-loader)
+# babel-loader [![NPM Status](https://img.shields.io/npm/v/babel-loader.svg?style=flat)](https://www.npmjs.com/package/babel-loader) [![Build Status](https://travis-ci.org/babel/babel-loader.svg?branch=master)](https://travis-ci.org/babel/babel-loader)
   > Babel is a compiler for writing next generation JavaScript.
 
   This package allows transpiling JavaScript files using [Babel](https://github.com/babel/babel) and [webpack](https://github.com/webpack/webpack).

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# babel-loader [![NPM Status](https://img.shields.io/npm/v/babel-loader.svg?style=flat)](https://www.npmjs.com/package/babel-loader) [![Build Status](https://travis-ci.org/babel/babel-loader.svg?branch=master)](https://travis-ci.org/babel/babel-loader)
+# babel-loader [![NPM Status](https://img.shields.io/npm/v/babel-loader.svg?style=flat)](https://www.npmjs.com/package/babel-loader) [![Build Status](https://travis-ci.org/babel/babel-loader.svg?branch=master)](https://travis-ci.org/babel/babel-loader)[![codecov](https://codecov.io/gh/babel/babel-loader/branch/master/graph/badge.svg)](https://codecov.io/gh/babel/babel-loader)
   > Babel is a compiler for writing next generation JavaScript.
 
   This package allows transpiling JavaScript files using [Babel](https://github.com/babel/babel) and [webpack](https://github.com/webpack/webpack).

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# babel-loader [![NPM Status](https://img.shields.io/npm/v/babel-loader.svg?style=flat)](https://www.npmjs.com/package/babel-loader) [![Build Status](https://travis-ci.org/babel/babel-loader.svg?branch=master)](https://travis-ci.org/babel/babel-loader)[![codecov](https://codecov.io/gh/babel/babel-loader/branch/master/graph/badge.svg)](https://codecov.io/gh/babel/babel-loader)
+# babel-loader [![NPM Status](https://img.shields.io/npm/v/babel-loader.svg?style=flat)](https://www.npmjs.com/package/babel-loader) [![Build Status](https://travis-ci.org/babel/babel-loader.svg?branch=master)](https://travis-ci.org/babel/babel-loader) [![codecov](https://codecov.io/gh/babel/babel-loader/branch/master/graph/badge.svg)](https://codecov.io/gh/babel/babel-loader)
   > Babel is a compiler for writing next generation JavaScript.
 
   This package allows transpiling JavaScript files using [Babel](https://github.com/babel/babel) and [webpack](https://github.com/webpack/webpack).

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ module: {
 
   * `cacheDirectory`: Default `false`. When set, the given directory will be used to cache the results of the loader. Future webpack builds will attempt to read from the cache to avoid needing to run the potentially expensive Babel recompilation process on each run. If the value is blank (`loader: 'babel-loader?cacheDirectory'`) the loader will use the default OS temporary file directory.
 
-  * `cacheIdentifier`: Default is a string composed by the babel-core's version, the babel-loader's version and the contents of .babelrc file if it exists. This can set to a custom value to force cache busting if the identifier changes.
+  * `cacheIdentifier`: Default is a string composed by the babel-core's version, the babel-loader's version, the contents of .babelrc file if it exists and the value of the environment variable `BABEL_ENV` with a fallback to the `NODE_ENV` environment variable. This can be set to a custom value to force cache busting if the identifier changes.
 
 
   __Note:__ The `sourceMap` option is ignored, instead sourceMaps are automatically enabled when webpack is configured to use them (via the `devtool` config option).

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# babel-loader [![Build Status](https://travis-ci.org/babel/babel-loader.svg?branch=master)](https://travis-ci.org/babel/babel-loader)
+# babel-loader [![NPM Status](https://img.shields.io/npm/v/babel-loader.svg?style=flat)](https://www.npmjs.com/package/babel-loader) [![Build Status](https://travis-ci.org/babel/babel-loader.svg?branch=master)](https://travis-ci.org/babel/babel-loader)[![codecov](https://codecov.io/gh/babel/babel-loader/branch/master/graph/badge.svg)](https://codecov.io/gh/babel/babel-loader)
   > Babel is a compiler for writing next generation JavaScript.
 
   This package allows transpiling JavaScript files using [Babel](https://github.com/babel/babel) and [webpack](https://github.com/webpack/webpack).
@@ -25,7 +25,7 @@ __Note:__ If you're upgrading from babel 5 to babel 6, please take a look [at th
 module: {
   loaders: [
     {
-      test: /\.jsx?$/,
+      test: /\.js$/,
       exclude: /(node_modules|bower_components)/,
       loader: 'babel', // 'babel-loader' is also a legal name to reference
       query: {
@@ -46,7 +46,7 @@ You can pass options to the loader by writing them as a [query string](https://g
 module: {
   loaders: [
     {
-      test: /\.jsx?$/,
+      test: /\.js$/,
       exclude: /(node_modules|bower_components)/,
       loader: 'babel?presets[]=es2015'
     }
@@ -60,7 +60,7 @@ module: {
 module: {
   loaders: [
     {
-      test: /\.jsx?$/,
+      test: /\.js$/,
       exclude: /(node_modules|bower_components)/,
       loader: 'babel',
       query: {
@@ -75,7 +75,7 @@ module: {
 
   * `cacheDirectory`: Default `false`. When set, the given directory will be used to cache the results of the loader. Future webpack builds will attempt to read from the cache to avoid needing to run the potentially expensive Babel recompilation process on each run. If the value is blank (`loader: 'babel-loader?cacheDirectory'`) the loader will use the default OS temporary file directory.
 
-  * `cacheIdentifier`: Default is a string composed by the babel-core's version, the babel-loader's version and the contents of .babelrc file if it exists. This can set to a custom value to force cache busting if the identifier changes.
+  * `cacheIdentifier`: Default is a string composed by the babel-core's version, the babel-loader's version, the contents of .babelrc file if it exists and the value of the environment variable `BABEL_ENV` with a fallback to the `NODE_ENV` environment variable. This can be set to a custom value to force cache busting if the identifier changes.
 
 
   __Note:__ The `sourceMap` option is ignored, instead sourceMaps are automatically enabled when webpack is configured to use them (via the `devtool` config option).
@@ -105,14 +105,14 @@ module: {
 
   See the [docs](http://babeljs.io/docs/plugins/transform-runtime/) for more information.
 
-  **NOTE:** You must run `npm install babel-plugin-transform-runtime --save-dev` to include this in your project.
+  **NOTE:** You must run `npm install babel-plugin-transform-runtime --save-dev` to include this in your project and `babel-runtime` itelf as a dependency with `npm install babel-runtime --save`.
 
 ```javascript
 loaders: [
   // the 'transform-runtime' plugin tells babel to require the runtime
   // instead of inlining it.
   {
-    test: /\.jsx?$/,
+    test: /\.js$/,
     exclude: /(node_modules|bower_components)/,
     loader: 'babel',
     query: {
@@ -128,7 +128,7 @@ loaders: [
 If using cacheDirectory results in an error similar to the following:
 
 ```
-ERROR in ./frontend/src/main.jsx
+ERROR in ./frontend/src/main.js
 Module build failed: Error: ENOENT, open 'true/350c59cae6b7bce3bb58c8240147581bfdc9cccc.json.gzip'
  @ multi app
 ```
@@ -139,7 +139,7 @@ That means that most likely, you're not setting the options correctly, and you'r
 ```javascript
 loaders: [
   {
-    test: /\.jsx?$/,
+    test: /\.js$/,
     exclude: /(node_modules|bower_components)/,
     loader: 'babel?cacheDirectory=true'
   }
@@ -151,7 +151,7 @@ That's not the correct way of setting boolean values. You should do instead:
 ```javascript
 loaders: [
   {
-    test: /\.jsx?$/,
+    test: /\.js$/,
     exclude: /(node_modules|bower_components)/,
     loader: 'babel?cacheDirectory'
   }
@@ -165,7 +165,7 @@ loaders: [
   // the optional 'runtime' transformer tells babel to require the runtime
   // instead of inlining it.
   {
-    test: /\.jsx?$/,
+    test: /\.js$/,
     exclude: /(node_modules|bower_components)/,
     loader: 'babel',
     query: {

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# babel-loader [![NPM Status](https://img.shields.io/npm/v/babel-loader.svg?style=flat)](https://www.npmjs.com/package/babel-loader) [![Build Status](https://travis-ci.org/babel/babel-loader.svg?branch=master)](https://travis-ci.org/babel/babel-loader) [![codecov](https://codecov.io/gh/babel/babel-loader/branch/master/graph/badge.svg)](https://codecov.io/gh/babel/babel-loader)
+# babel-loader [![Build Status](https://travis-ci.org/babel/babel-loader.svg?branch=master)](https://travis-ci.org/babel/babel-loader)
   > Babel is a compiler for writing next generation JavaScript.
 
   This package allows transpiling JavaScript files using [Babel](https://github.com/babel/babel) and [webpack](https://github.com/webpack/webpack).
@@ -25,7 +25,7 @@ __Note:__ If you're upgrading from babel 5 to babel 6, please take a look [at th
 module: {
   loaders: [
     {
-      test: /\.js$/,
+      test: /\.jsx?$/,
       exclude: /(node_modules|bower_components)/,
       loader: 'babel', // 'babel-loader' is also a legal name to reference
       query: {
@@ -46,7 +46,7 @@ You can pass options to the loader by writing them as a [query string](https://g
 module: {
   loaders: [
     {
-      test: /\.js$/,
+      test: /\.jsx?$/,
       exclude: /(node_modules|bower_components)/,
       loader: 'babel?presets[]=es2015'
     }
@@ -60,7 +60,7 @@ module: {
 module: {
   loaders: [
     {
-      test: /\.js$/,
+      test: /\.jsx?$/,
       exclude: /(node_modules|bower_components)/,
       loader: 'babel',
       query: {
@@ -75,7 +75,7 @@ module: {
 
   * `cacheDirectory`: Default `false`. When set, the given directory will be used to cache the results of the loader. Future webpack builds will attempt to read from the cache to avoid needing to run the potentially expensive Babel recompilation process on each run. If the value is blank (`loader: 'babel-loader?cacheDirectory'`) the loader will use the default OS temporary file directory.
 
-  * `cacheIdentifier`: Default is a string composed by the babel-core's version, the babel-loader's version, the contents of .babelrc file if it exists and the value of the environment variable `BABEL_ENV` with a fallback to the `NODE_ENV` environment variable. This can be set to a custom value to force cache busting if the identifier changes.
+  * `cacheIdentifier`: Default is a string composed by the babel-core's version, the babel-loader's version and the contents of .babelrc file if it exists. This can set to a custom value to force cache busting if the identifier changes.
 
 
   __Note:__ The `sourceMap` option is ignored, instead sourceMaps are automatically enabled when webpack is configured to use them (via the `devtool` config option).
@@ -105,14 +105,14 @@ module: {
 
   See the [docs](http://babeljs.io/docs/plugins/transform-runtime/) for more information.
 
-  **NOTE:** You must run `npm install babel-plugin-transform-runtime --save-dev` to include this in your project and `babel-runtime` itself as a dependency with `npm install babel-runtime --save`.
+  **NOTE:** You must run `npm install babel-plugin-transform-runtime --save-dev` to include this in your project.
 
 ```javascript
 loaders: [
   // the 'transform-runtime' plugin tells babel to require the runtime
   // instead of inlining it.
   {
-    test: /\.js$/,
+    test: /\.jsx?$/,
     exclude: /(node_modules|bower_components)/,
     loader: 'babel',
     query: {
@@ -128,7 +128,7 @@ loaders: [
 If using cacheDirectory results in an error similar to the following:
 
 ```
-ERROR in ./frontend/src/main.js
+ERROR in ./frontend/src/main.jsx
 Module build failed: Error: ENOENT, open 'true/350c59cae6b7bce3bb58c8240147581bfdc9cccc.json.gzip'
  @ multi app
 ```
@@ -139,7 +139,7 @@ That means that most likely, you're not setting the options correctly, and you'r
 ```javascript
 loaders: [
   {
-    test: /\.js$/,
+    test: /\.jsx?$/,
     exclude: /(node_modules|bower_components)/,
     loader: 'babel?cacheDirectory=true'
   }
@@ -151,7 +151,7 @@ That's not the correct way of setting boolean values. You should do instead:
 ```javascript
 loaders: [
   {
-    test: /\.js$/,
+    test: /\.jsx?$/,
     exclude: /(node_modules|bower_components)/,
     loader: 'babel?cacheDirectory'
   }
@@ -165,7 +165,7 @@ loaders: [
   // the optional 'runtime' transformer tells babel to require the runtime
   // instead of inlining it.
   {
-    test: /\.js$/,
+    test: /\.jsx?$/,
     exclude: /(node_modules|bower_components)/,
     loader: 'babel',
     query: {

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ __Note:__ If you're upgrading from babel 5 to babel 6, please take a look [at th
 module: {
   loaders: [
     {
-      test: /\.jsx?$/,
+      test: /\.js$/,
       exclude: /(node_modules|bower_components)/,
       loader: 'babel', // 'babel-loader' is also a legal name to reference
       query: {
@@ -46,7 +46,7 @@ You can pass options to the loader by writing them as a [query string](https://g
 module: {
   loaders: [
     {
-      test: /\.jsx?$/,
+      test: /\.js$/,
       exclude: /(node_modules|bower_components)/,
       loader: 'babel?presets[]=es2015'
     }
@@ -60,7 +60,7 @@ module: {
 module: {
   loaders: [
     {
-      test: /\.jsx?$/,
+      test: /\.js$/,
       exclude: /(node_modules|bower_components)/,
       loader: 'babel',
       query: {
@@ -112,7 +112,7 @@ loaders: [
   // the 'transform-runtime' plugin tells babel to require the runtime
   // instead of inlining it.
   {
-    test: /\.jsx?$/,
+    test: /\.js$/,
     exclude: /(node_modules|bower_components)/,
     loader: 'babel',
     query: {
@@ -128,7 +128,7 @@ loaders: [
 If using cacheDirectory results in an error similar to the following:
 
 ```
-ERROR in ./frontend/src/main.jsx
+ERROR in ./frontend/src/main.js
 Module build failed: Error: ENOENT, open 'true/350c59cae6b7bce3bb58c8240147581bfdc9cccc.json.gzip'
  @ multi app
 ```
@@ -139,7 +139,7 @@ That means that most likely, you're not setting the options correctly, and you'r
 ```javascript
 loaders: [
   {
-    test: /\.jsx?$/,
+    test: /\.js$/,
     exclude: /(node_modules|bower_components)/,
     loader: 'babel?cacheDirectory=true'
   }
@@ -151,7 +151,7 @@ That's not the correct way of setting boolean values. You should do instead:
 ```javascript
 loaders: [
   {
-    test: /\.jsx?$/,
+    test: /\.js$/,
     exclude: /(node_modules|bower_components)/,
     loader: 'babel?cacheDirectory'
   }
@@ -165,7 +165,7 @@ loaders: [
   // the optional 'runtime' transformer tells babel to require the runtime
   // instead of inlining it.
   {
-    test: /\.jsx?$/,
+    test: /\.js$/,
     exclude: /(node_modules|bower_components)/,
     loader: 'babel',
     query: {

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# babel-loader [![NPM Status](https://img.shields.io/npm/v/babel-loader.svg?style=flat)](https://www.npmjs.com/package/babel-loader) [![Build Status](https://travis-ci.org/babel/babel-loader.svg?branch=master)](https://travis-ci.org/babel/babel-loader) [![codecov](https://codecov.io/gh/babel/babel-loader/branch/master/graph/badge.svg)](https://codecov.io/gh/babel/babel-loader)
+# babel-loader [![Build Status](https://travis-ci.org/babel/babel-loader.svg?branch=master)](https://travis-ci.org/babel/babel-loader)
   > Babel is a compiler for writing next generation JavaScript.
 
   This package allows transpiling JavaScript files using [Babel](https://github.com/babel/babel) and [webpack](https://github.com/webpack/webpack).
@@ -25,7 +25,7 @@ __Note:__ If you're upgrading from babel 5 to babel 6, please take a look [at th
 module: {
   loaders: [
     {
-      test: /\.js$/,
+      test: /\.jsx?$/,
       exclude: /(node_modules|bower_components)/,
       loader: 'babel', // 'babel-loader' is also a legal name to reference
       query: {
@@ -46,7 +46,7 @@ You can pass options to the loader by writing them as a [query string](https://g
 module: {
   loaders: [
     {
-      test: /\.js$/,
+      test: /\.jsx?$/,
       exclude: /(node_modules|bower_components)/,
       loader: 'babel?presets[]=es2015'
     }
@@ -60,7 +60,7 @@ module: {
 module: {
   loaders: [
     {
-      test: /\.js$/,
+      test: /\.jsx?$/,
       exclude: /(node_modules|bower_components)/,
       loader: 'babel',
       query: {
@@ -75,7 +75,7 @@ module: {
 
   * `cacheDirectory`: Default `false`. When set, the given directory will be used to cache the results of the loader. Future webpack builds will attempt to read from the cache to avoid needing to run the potentially expensive Babel recompilation process on each run. If the value is blank (`loader: 'babel-loader?cacheDirectory'`) the loader will use the default OS temporary file directory.
 
-  * `cacheIdentifier`: Default is a string composed by the babel-core's version, the babel-loader's version, the contents of .babelrc file if it exists and the value of the environment variable `BABEL_ENV` with a fallback to the `NODE_ENV` environment variable. This can be set to a custom value to force cache busting if the identifier changes.
+  * `cacheIdentifier`: Default is a string composed by the babel-core's version, the babel-loader's version and the contents of .babelrc file if it exists. This can set to a custom value to force cache busting if the identifier changes.
 
 
   __Note:__ The `sourceMap` option is ignored, instead sourceMaps are automatically enabled when webpack is configured to use them (via the `devtool` config option).
@@ -105,14 +105,14 @@ module: {
 
   See the [docs](http://babeljs.io/docs/plugins/transform-runtime/) for more information.
 
-  **NOTE:** You must run `npm install babel-plugin-transform-runtime --save-dev` to include this in your project and `babel-runtime` itelf as a dependency with `npm install babel-runtime --save`.
+  **NOTE:** You must run `npm install babel-plugin-transform-runtime --save-dev` to include this in your project.
 
 ```javascript
 loaders: [
   // the 'transform-runtime' plugin tells babel to require the runtime
   // instead of inlining it.
   {
-    test: /\.js$/,
+    test: /\.jsx?$/,
     exclude: /(node_modules|bower_components)/,
     loader: 'babel',
     query: {
@@ -128,7 +128,7 @@ loaders: [
 If using cacheDirectory results in an error similar to the following:
 
 ```
-ERROR in ./frontend/src/main.js
+ERROR in ./frontend/src/main.jsx
 Module build failed: Error: ENOENT, open 'true/350c59cae6b7bce3bb58c8240147581bfdc9cccc.json.gzip'
  @ multi app
 ```
@@ -139,7 +139,7 @@ That means that most likely, you're not setting the options correctly, and you'r
 ```javascript
 loaders: [
   {
-    test: /\.js$/,
+    test: /\.jsx?$/,
     exclude: /(node_modules|bower_components)/,
     loader: 'babel?cacheDirectory=true'
   }
@@ -151,7 +151,7 @@ That's not the correct way of setting boolean values. You should do instead:
 ```javascript
 loaders: [
   {
-    test: /\.js$/,
+    test: /\.jsx?$/,
     exclude: /(node_modules|bower_components)/,
     loader: 'babel?cacheDirectory'
   }
@@ -165,7 +165,7 @@ loaders: [
   // the optional 'runtime' transformer tells babel to require the runtime
   // instead of inlining it.
   {
-    test: /\.js$/,
+    test: /\.jsx?$/,
     exclude: /(node_modules|bower_components)/,
     loader: 'babel',
     query: {

--- a/index.js
+++ b/index.js
@@ -66,15 +66,13 @@ var transpile = function(source, options) {
   return {
     code: code,
     map: map,
-    metadata: metadata
+    metadata: metadata,
   };
 };
 
 
 function passMetadata(s, context, metadata) {
-  //console.log("s:",s,"metadata:",metadata,"context:",context);
   if (context[s]) {
-    //console.log("context function:",context[s].toString());
     context[s](metadata);
   }
 }
@@ -139,12 +137,16 @@ module.exports = function(source, inputSourceMap) {
       transform: transpile,
     }, function(err, result) {
       if (err) { return callback(err); }
-      metadataSubscribers.map(function (s) {passMetadata(s, context, result.metadata);});
+      metadataSubscribers.map(function(s) {
+        passMetadata(s, context, result.metadata);
+      });
       return callback(null, result.code, result.map);
     });
   }
 
   result = transpile(source, options);
-  metadataSubscribers.map(function (s) {passMetadata(s, context, result.metadata);});
+  metadataSubscribers.map(function(s) {
+    passMetadata(s, context, result.metadata);
+  });
   this.callback(null, result.code, result.map);
 };

--- a/index.js
+++ b/index.js
@@ -139,12 +139,12 @@ module.exports = function(source, inputSourceMap) {
       transform: transpile,
     }, function(err, result) {
       if (err) { return callback(err); }
-      metadataSubscribers.map(function (s) {passMetadata(s, context, result.metadata)});
+      metadataSubscribers.map(function (s) {passMetadata(s, context, result.metadata);});
       return callback(null, result.code, result.map);
     });
   }
 
   result = transpile(source, options);
-  metadataSubscribers.map(function (s) {passMetadata(s, context, result.metadata)});
+  metadataSubscribers.map(function (s) {passMetadata(s, context, result.metadata);});
   this.callback(null, result.code, result.map);
 };

--- a/index.js
+++ b/index.js
@@ -57,6 +57,7 @@ var transpile = function(source, options) {
   }
   var code = result.code;
   var map = result.map;
+  var metadata = result.metadata;
 
   if (map && (!map.sourcesContent || !map.sourcesContent.length)) {
     map.sourcesContent = [source];
@@ -65,8 +66,18 @@ var transpile = function(source, options) {
   return {
     code: code,
     map: map,
+    metadata: metadata
   };
 };
+
+
+function passMetadata(s, context, metadata) {
+  //console.log("s:",s,"metadata:",metadata,"context:",context);
+  if (context[s]) {
+    //console.log("context function:",context[s].toString());
+    context[s](metadata);
+  }
+}
 
 module.exports = function(source, inputSourceMap) {
   var result = {};
@@ -80,6 +91,7 @@ module.exports = function(source, inputSourceMap) {
   var loaderOptions = loaderUtils.parseQuery(this.query);
   var userOptions = assign({}, globalOptions, loaderOptions);
   var defaultOptions = {
+    metadataSubscribers: [],
     inputSourceMap: inputSourceMap,
     sourceRoot: process.cwd(),
     filename: filename,
@@ -108,11 +120,14 @@ module.exports = function(source, inputSourceMap) {
 
   var cacheDirectory = options.cacheDirectory;
   var cacheIdentifier = options.cacheIdentifier;
+  var metadataSubscribers = options.metadataSubscribers;
 
   delete options.cacheDirectory;
   delete options.cacheIdentifier;
+  delete options.metadataSubscribers;
 
   this.cacheable();
+  var context = this;
 
   if (cacheDirectory) {
     var callback = this.async();
@@ -124,10 +139,12 @@ module.exports = function(source, inputSourceMap) {
       transform: transpile,
     }, function(err, result) {
       if (err) { return callback(err); }
+      metadataSubscribers.map(function (s) {passMetadata(s, context, result.metadata)});
       return callback(null, result.code, result.map);
     });
   }
 
   result = transpile(source, options);
+  metadataSubscribers.map(function (s) {passMetadata(s, context, result.metadata)});
   this.callback(null, result.code, result.map);
 };

--- a/package.json
+++ b/package.json
@@ -24,6 +24,8 @@
     "jshint": "^2.8.0",
     "mocha": "^2.3.3",
     "rimraf": "^2.4.3",
+    "react": "^15.1.0",
+    "react-intl":"^2.1.2",
     "babel-plugin-react-intl": "2.1.3",
     "react-intl-webpack-plugin":"0.0.3"
   },

--- a/package.json
+++ b/package.json
@@ -23,7 +23,9 @@
     "jscs": "^2.5.0",
     "jshint": "^2.8.0",
     "mocha": "^2.3.3",
-    "rimraf": "^2.4.3"
+    "rimraf": "^2.4.3",
+    "babel-plugin-react-intl": "2.1.3",
+    "react-intl-webpack-plugin":"0.0.3"
   },
   "scripts": {
     "test": "npm run hint && npm run cs && npm run cover",

--- a/test/fixtures/metadata.js
+++ b/test/fixtures/metadata.js
@@ -1,0 +1,15 @@
+import {defineMessages} from 'react-intl';
+class App {
+  constructor(arg='test') {
+    var m = defineMessages({
+      greeting: {
+        id: 'greetingId',
+        defaultMessage: 'Hello World!'
+      },
+    });
+
+    this.result = arg;
+  }
+}
+
+export default App;

--- a/test/fixtures/metadataErr.js
+++ b/test/fixtures/metadataErr.js
@@ -1,0 +1,16 @@
+import {defineMessages} from 'react-intl';
+class App {
+  constructor(arg='test') {
+    var m = defineMessages({
+      greeting: {
+        id: 'greetingId',
+        defaultMessage: 'Hello World!'
+      },
+    });
+
+    bla bla
+    this.result = arg;
+  }
+}
+
+export default App;

--- a/test/metadata.test.js
+++ b/test/metadata.test.js
@@ -82,6 +82,18 @@ describe('Metadata', function() {
     });
   });
 
+  it('should throw error ', function(done) {
+    var config = assign({}, globalConfig, {
+      entry: './test/fixtures/metadataErr.js',
+    });
+
+    webpack(config, function(err, stats) {
+      expect(stats.compilation.errors.length).to.be.greaterThan(0);
+      return done();
+    });
+  });
+
+
 });
 
 

--- a/test/metadata.test.js
+++ b/test/metadata.test.js
@@ -1,0 +1,87 @@
+'use strict';
+
+var fs = require('fs');
+var path = require('path');
+var assign = require('object-assign');
+var expect = require('expect.js');
+var mkdirp = require('mkdirp');
+var rimraf = require('rimraf');
+var webpack = require('webpack');
+
+var ReactIntlPlugin = require('react-intl-webpack-plugin');
+
+describe('Metadata', function() {
+
+  var outputDir = path.resolve(__dirname, './output/metadata');
+  var babelLoader = path.resolve(__dirname, '../');
+  var globalConfig = {
+    entry: './test/fixtures/metadata.js',
+    output: {
+      path: outputDir,
+      filename: '[id].metadata.js',
+    },
+    plugins: [new ReactIntlPlugin(),],
+    module: {
+      loaders: [
+        {
+          test: /\.jsx?/,
+          loader: babelLoader,
+          query: {
+            metadataSubscribers: [ReactIntlPlugin.metadataContextFunctionName],
+            plugins: [
+              ['react-intl', {enforceDescriptions: false,},],
+            ],
+            presets: [],
+          },
+          exclude: /node_modules/,
+        },
+      ],
+    },
+  };
+
+  // Clean generated cache files before each test
+  // so that we can call each test with an empty state.
+  beforeEach(function(done) {
+    rimraf(outputDir, function(err) {
+      if (err) { return done(err); }
+      mkdirp(outputDir, done);
+    });
+  });
+
+  it('should pass metadata code snippet', function(done) {
+    var config = assign({}, globalConfig, {
+    });
+
+    webpack(config, function(err, stats) {
+      expect(err).to.be(null);
+
+      fs.readdir(outputDir, function(err, files) {
+        expect(err).to.be(null);
+        fs.readFile(path.resolve(outputDir, 'reactIntlMessages.json'),
+          function(err, data) {
+            var text = data.toString();
+            expect(err).to.be(null);
+            // TODO expect(subject.indexOf(test)).to.not.equal(-1);
+            var jsonText = JSON.parse(text);
+            expect(jsonText.length).to.be(1);
+            expect(jsonText[0].id).to.be('greetingId');
+            expect(jsonText[0].defaultMessage).to.be('Hello World!');
+
+            return done();
+          });
+      });
+    });
+  });
+
+  it('should not throw error ', function(done) {
+    var config = assign({}, globalConfig, {});
+
+    webpack(config, function(err, stats) {
+      expect(stats.compilation.errors.length).to.be(0);
+      return done();
+    });
+  });
+
+});
+
+


### PR DESCRIPTION
- add metadataSubscribers option as an array of context functions to call
- pass metadata to metadataSubscribers functions
- add .idea to .gitignore

This is needed when generating messages for translation from modules:
- there is the babel-react-intl plugin, which returns the messages it finds in the module in the metadata[react-int] property. (babel returns not only source code and source map but also the ast and the metadata property )
- since babel loader returns only source code and source map, I extended it to return metadata too. A webpack plugin is now able to aggregate all this metadata...

I will publish such a plugin asap (ReactIntlPlugin)
