### PR TITLE
fix doc of cacheDirecotry

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,12 @@ module: {
 
   This loader also supports the following loader-specific option:
 
-  * `cacheDirectory`: Default `false`. When set, the given directory will be used to cache the results of the loader. Future webpack builds will attempt to read from the cache to avoid needing to run the potentially expensive Babel recompilation process on each run. If the value is blank (`loader: 'babel-loader?cacheDirectory'`) the loader will use the default OS temporary file directory.
+  * `cacheDirectory`: Default `false`. When set, the given directory will be used to cache the results of the loader. Future webpack builds will attempt to read from the cache to avoid needing to run the potentially expensive Babel recompilation process on each run. If you want loader to use the default OS temporary file directory, you can set set it to true.
+  ```javascript
+    query: {
+      cacheDirectory: true
+    }
+  ```
 
   * `cacheIdentifier`: Default is a string composed by the babel-core's version, the babel-loader's version and the contents of .babelrc file if it exists. This can set to a custom value to force cache busting if the identifier changes.
 


### PR DESCRIPTION
When I use 
```javascript
loader: 'babel?cacheDirectory'
```
[this line](https://github.com/babel/babel-loader/blob/master/index.js#L32)
```javascript
var loaderOptions = loaderUtils.parseQuery(this.query)
```
returns an object without the key ```cacheDirectory```.
Its causes [this line](https://github.com/babel/babel-loader/blob/master/index.js#L66)
```javascript
var cacheDirectory = options.cacheDirectory
```
returning ```undefined```, so later [cacheDirectory detection](https://github.com/babel/babel-loader/blob/master/index.js#L74) always fails.