### PR TITLE
fix options.sourceFileName gennerate bug

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,0 +1,91 @@
+'use strict';
+
+var assign = require('object-assign');
+var babel = require('babel-core');
+var loaderUtils = require('loader-utils');
+var cache = require('./lib/fs-cache.js');
+var exists = require('./lib/helpers/exists')();
+var read = require('./lib/helpers/read')();
+var resolveRc = require('./lib/resolve-rc.js');
+var relative = require('./lib/helpers/relative');
+var pkg = require('./package.json');
+var path = require('path');
+
+var transpile = function(source, options) {
+  var result = babel.transform(source, options);
+  var code = result.code;
+  var map = result.map;
+
+  if (map && (!map.sourcesContent || !map.sourcesContent.length)) {
+    map.sourcesContent = [source];
+  }
+
+  return {
+    code: code,
+    map: map,
+  };
+};
+
+module.exports = function(source, inputSourceMap) {
+  var result = {};
+
+  // Handle filenames (#106)
+  var webpackRemainingChain = loaderUtils.getRemainingRequest(this).split('!');
+  var filename = webpackRemainingChain[webpackRemainingChain.length - 1];
+
+  // Handle options
+  var globalOptions = this.options.babel || {};
+  var loaderOptions = loaderUtils.parseQuery(this.query);
+  var userOptions = assign({}, globalOptions, loaderOptions);
+  var defaultOptions = {
+    inputSourceMap: inputSourceMap,
+    sourceRoot: process.cwd(),
+    filename: filename,
+    cacheIdentifier: JSON.stringify({
+      'babel-loader': pkg.version,
+      'babel-core': babel.version,
+      babelrc: exists(userOptions.babelrc) ?
+          read(userOptions.babelrc) :
+          resolveRc(path.dirname(filename)),
+      env: process.env.BABEL_ENV || process.env.NODE_ENV,
+    }),
+  };
+
+  var options = assign({}, defaultOptions, userOptions);
+
+  if (userOptions.sourceMap === undefined) {
+    options.sourceMap = this.sourceMap;
+  }
+
+  if (options.sourceFileName === undefined) {
+    options.sourceFileName = relative(
+        options.sourceRoot,
+        options.filename
+    );
+  }
+
+  var cacheDirectory = options.cacheDirectory;
+  var cacheIdentifier = options.cacheIdentifier;
+
+  delete options.cacheDirectory;
+  delete options.cacheIdentifier;
+
+  this.cacheable();
+
+  if (cacheDirectory) {
+    var callback = this.async();
+    return cache({
+      directory: cacheDirectory,
+      identifier: cacheIdentifier,
+      source: source,
+      options: options,
+      transform: transpile,
+    }, function(err, result) {
+      if (err) { return callback(err); }
+      return callback(null, result.code, result.map);
+    });
+  }
+
+  result = transpile(source, options);
+  this.callback(null, result.code, result.map);
+};

--- a/src/index.js
+++ b/src/index.js
@@ -4,6 +4,7 @@ const loaderUtils = require("loader-utils");
 const path = require("path");
 const cache = require("./fs-cache.js");
 const exists = require("./utils/exists")();
+const relative = require("./utils/relative");
 const read = require("./utils/read")();
 const resolveRc = require("./resolve-rc.js");
 const pkg = require("./../package.json");
@@ -98,9 +99,9 @@ module.exports = function(source, inputSourceMap) {
   }
 
   if (options.sourceFileName === undefined) {
-    options.sourceFileName = path.relative(
-        options.sourceRoot,
-        options.filename
+    options.sourceFileName = relative(
+      options.sourceRoot,
+      options.filename
     );
   }
 

--- a/src/utils/relative.js
+++ b/src/utils/relative.js
@@ -1,0 +1,39 @@
+/**
+* Make a path relative to a URL or another path.
+* Borrowed from https://github.com/mozilla/source-map/blob/master/lib/util.js
+*
+* @param aRoot The root path or URL.
+* @param aPath The path or URL to be made relative to aRoot.
+*/
+module.exports = function relative(aRoot, aPath) {
+  if (aRoot === "") {
+    aRoot = ".";
+  }
+
+  aRoot = aRoot.replace(/\/$/, "");
+
+  // It is possible for the path to be above the root. In this case, simply
+  // checking whether the root is a prefix of the path won't work. Instead, we
+  // need to remove components from the root one by one, until either we find
+  // a prefix that fits, or we run out of components to remove.
+  let level = 0;
+  while (aPath.indexOf(aRoot + "/") !== 0) {
+    const index = aRoot.lastIndexOf("/");
+    if (index < 0) {
+      return aPath;
+    }
+
+    // If the only part of the root that is left is the scheme (i.e. http://,
+    // file:///, etc.), one or more slashes (/), or simply nothing at all, we
+    // have exhausted all components, so the path is not relative to the root.
+    aRoot = aRoot.slice(0, index);
+    if (aRoot.match(/^([^\/]+:\/)?\/*$/)) {
+      return aPath;
+    }
+
+    ++level;
+  }
+
+  // Make sure we add a '../' for each component we removed from the root.
+  return Array(level + 1).join("../") + aPath.substr(aRoot.length + 1);
+};

--- a/test/utils/relative.test.js
+++ b/test/utils/relative.test.js
@@ -1,0 +1,16 @@
+import test from "ava";
+import relative from "../../lib/utils/relative.js";
+
+test("should get correct relative path", (t) => {
+  t.is(relative("/the/root", "/the/root/one.js"), "one.js");
+  t.is(relative("/the/root", "/the/rootone.js"), "../rootone.js");
+  t.is(relative("/the/root", "/therootone.js"), "/therootone.js");
+
+  t.is(relative("", "/the/root/one.js"), "/the/root/one.js");
+  t.is(relative(".", "/the/root/one.js"), "/the/root/one.js");
+  t.is(relative("", "the/root/one.js"), "the/root/one.js");
+  t.is(relative(".", "the/root/one.js"), "the/root/one.js");
+
+  t.is(relative("/", "/the/root/one.js"), "the/root/one.js");
+  t.is(relative("/", "the/root/one.js"), "the/root/one.js");
+});


### PR DESCRIPTION
One corner usage:

```
sourceRoot: '/Users/me/work/SugarDev',
filename: '/private/tmp/wow/app.js'

// with previous path.relative
sourceFileName: '../../../../private/tmp/wow/app.js'
```

It seems just okay, but when `webpack` use `webpack.optimize.UglifyJsPlugin` with sourceMap, compilation will run into error. Because `webpack.optimize.UglifyJsPlugin` will try to access source map via `'/private/tmp/wow/app.js'`.

More info see https://github.com/webpack/webpack/issues/2616

So we should fix the `relative`.

`webpack` use `source-map` handle source map, and `source-map` use its own `relative`: https://github.com/mozilla/source-map/blob/master/lib/util.js#L188-L226

Here I just replace `path.relative` with `source-map`'s `util.relative`, and It will fix this error.
