### PR TITLE
add babel-core and preset-2015 to dev dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,6 @@ before_install:
   - npm --version
 before_script:
   - 'if [ "$WEBPACK_VERSION" ]; then npm install webpack@^$WEBPACK_VERSION; fi'
-  - npm install babel-core babel-preset-es2015
 script:
   - npm run travis
 after_success:

--- a/package.json
+++ b/package.json
@@ -16,6 +16,8 @@
     "webpack": "1 || ^2.1.0-beta"
   },
   "devDependencies": {
+    "babel-core": "^6.0.0",
+    "babel-preset-es2015": "^6.0.0",
     "expect.js": "^0.3.1",
     "istanbul": "^0.4.0",
     "jscs": "^2.5.0",


### PR DESCRIPTION
currently it is impossible to run tests after forking the `babel-loader` without installing `babel-core` and `babel-preset-2015` by hand. Adding them to the dev-dependencies will fix this. (I saw the dependencies as they are installed in the `before_script` according to the `.travis.yml`)