### PR TITLE
chore(ci): Expand Travis testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,28 @@
 sudo: false
 language: node_js
+os:
+  - linux
+  - osx
 node_js:
-  - stable
-  - '0'
-  - '0.10'
+  - node
+  - "6"
+  - "5"
+  - "4"
+env:
+  - export WEBPACK_VERSION="2.1.0-beta"
+  - export WEBPACK_VERSION="1"
+matrix:
+  fast_finish: true
+  allow_failures:
+    - os: osx
+before_install:
+  - nvm --version
+  - node --version
+  - npm --version
 before_script:
+  - 'if [ "$WEBPACK_VERSION" ]; then npm install webpack@^$WEBPACK_VERSION; fi'
   - npm install babel-core babel-preset-es2015
+script:
+  - npm run travis
+after_success:
+  - bash <(curl -s https://codecov.io/bash)

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# babel-loader [![NPM Status](https://img.shields.io/npm/v/babel-loader.svg?style=flat)](https://www.npmjs.com/package/babel-loader) [![Build Status](https://travis-ci.org/babel/babel-loader.svg?branch=master)](https://travis-ci.org/babel/babel-loader)
+# babel-loader [![NPM Status](https://img.shields.io/npm/v/babel-loader.svg?style=flat)](https://www.npmjs.com/package/babel-loader) [![Build Status](https://travis-ci.org/babel/babel-loader.svg?branch=master)](https://travis-ci.org/babel/babel-loader)[![codecov](https://codecov.io/gh/babel/babel-loader/branch/master/graph/badge.svg)](https://codecov.io/gh/babel/babel-loader)
   > Babel is a compiler for writing next generation JavaScript.
 
   This package allows transpiling JavaScript files using [Babel](https://github.com/babel/babel) and [webpack](https://github.com/webpack/webpack).

--- a/package.json
+++ b/package.json
@@ -21,12 +21,13 @@
     "jscs": "^2.5.0",
     "jshint": "^2.8.0",
     "mocha": "^2.3.3",
-    "rimraf": "^2.4.3",
-    "webpack": "^1.12.2"
+    "rimraf": "^2.4.3"
   },
   "scripts": {
-    "test": "npm run hint && npm run cs && npm run cov",
-    "cov": "istanbul cover ./node_modules/.bin/_mocha -- test/*.test.js",
+    "test": "npm run hint && npm run cs && npm run cover",
+    "travis": "npm run cover -- --report lcovonly",
+    "cover": "istanbul cover ./node_modules/.bin/_mocha -- test/*.test.js",
+    "postcover":"npm run hint && npm run cs",
     "hint": "jshint --config .jshintrc index.js lib/* test/*",
     "cs": "jscs --config .jscsrc index.js lib/* test/*"
   },


### PR DESCRIPTION
* REMOVE webpack devDependency as we have multiple peerDep versions
* Add matrix testing against supported node & webpack versions
* Enable codecov.io reporting
* Add travis script for test and coverage
* Rename cov script to cover to take advantage of `postcover`
* Add postcover script for travis linting after testing
* Temporarily allows failures on `OSX` ( timeout on node4 )

Resolves #239
Relates to #275