### PR TITLE
fix: Use inline sourcemaps when declared in devtool (#284)

### DIFF
--- a/index.js
+++ b/index.js
@@ -96,7 +96,12 @@ module.exports = function(source, inputSourceMap) {
   var options = assign({}, defaultOptions, userOptions);
 
   if (userOptions.sourceMap === undefined) {
-    options.sourceMap = this.sourceMap;
+    var devtool = this.options.devtool;
+    if (typeof devtool === 'string' && devtool.indexOf('inline') >= 0) {
+      options.sourceMap = 'inline';
+    } else {
+      options.sourceMap = this.sourceMap;
+    }
   }
 
   if (options.sourceFileName === undefined) {

--- a/test/sourcemaps.test.js
+++ b/test/sourcemaps.test.js
@@ -38,6 +38,44 @@ describe('Sourcemaps', function() {
     });
   });
 
+  it('should not output webpack\'s sourcemap', function(done) {
+
+    var config = assign({}, globalConfig, {
+      // No devtool selected
+      entry: './test/fixtures/basic.js',
+      module: {
+        loaders: [
+          {
+            test: /\.jsx?/,
+            loader: babelLoader + '?presets[]=es2015',
+            exclude: /node_modules/,
+          },
+        ],
+      },
+    });
+
+    webpack(config, function(err, stats) {
+      expect(err).to.be(null);
+
+      fs.readdir(outputDir, function(err, files) {
+        expect(err).to.be(null);
+
+        var map = files.filter(function(file) {
+          return (file.indexOf('.js') !== -1);
+        });
+
+        expect(map).to.not.be.empty();
+
+        fs.readFile(path.resolve(outputDir, map[0]), function(err, data) {
+          expect(err).to.be(null);
+          expect(data.toString().indexOf('//# sourceMappingURL')).to.equal(-1);
+          done();
+        });
+
+      });
+    });
+  });
+
   it('should output webpack\'s sourcemap', function(done) {
 
     var config = assign({}, globalConfig, {
@@ -69,6 +107,45 @@ describe('Sourcemaps', function() {
         fs.readFile(path.resolve(outputDir, map[0]), function(err, data) {
           expect(err).to.be(null);
           expect(data.toString().indexOf('webpack:///')).to.not.equal(-1);
+          done();
+        });
+
+      });
+    });
+  });
+
+  it('should output webpack\'s sourcemap inlined', function(done) {
+
+    var config = assign({}, globalConfig, {
+      devtool: 'inline-source-map',
+      entry: './test/fixtures/basic.js',
+      module: {
+        loaders: [
+          {
+            test: /\.jsx?/,
+            loader: babelLoader + '?presets[]=es2015',
+            exclude: /node_modules/,
+          },
+        ],
+      },
+    });
+
+    webpack(config, function(err, stats) {
+      expect(err).to.be(null);
+
+      fs.readdir(outputDir, function(err, files) {
+        expect(err).to.be(null);
+
+        var map = files.filter(function(file) {
+          return (file.indexOf('.js') !== -1);
+        });
+
+        expect(map).to.not.be.empty();
+
+        fs.readFile(path.resolve(outputDir, map[0]), function(err, data) {
+          expect(err).to.be(null);
+          var souceMapComment = '//# sourceMappingURL=data:application/json';
+          expect(data.toString().indexOf(souceMapComment)).to.not.equal(-1);
           done();
         });
 


### PR DESCRIPTION
**Please Read the [CONTRIBUTING Guidelines](https://github.com/babel/babel-loader/blob/master/CONTRIBUTING.md)**
*In particular the portion on Commit Message Formatting*

**Please check if the PR fulfills these requirements**
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] ~~Docs have been added / updated (for bug fixes / features)~~ I'd say it's already documented, kind of.

**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)

https://github.com/babel/babel-loader/issues/284

**What is the new behavior?**

Use inline sourcemaps when asked to.

**Does this PR introduce a breaking change?**
- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the following...

* Impact:
* Migration path for existing applications:
* Github Issue(s) this is regarding:


**Other information**:

