### PR TITLE
Use standard cache dir as default cacheDirectory

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ module: {
 
   This loader also supports the following loader-specific option:
 
-  * `cacheDirectory`: Default `false`. When set, the given directory will be used to cache the results of the loader. Future webpack builds will attempt to read from the cache to avoid needing to run the potentially expensive Babel recompilation process on each run. If the value is blank (`loader: 'babel-loader?cacheDirectory'`) the loader will use the default OS temporary file directory.
+  * `cacheDirectory`: Default `false`. When set, the given directory will be used to cache the results of the loader. Future webpack builds will attempt to read from the cache to avoid needing to run the potentially expensive Babel recompilation process on each run. If the value is blank (`loader: 'babel-loader?cacheDirectory'`) the loader will use the default cache directory in `node_modules/.cache/babel-loader`.
 
   * `cacheIdentifier`: Default is a string composed by the babel-core's version, the babel-loader's version, the contents of .babelrc file if it exists and the value of the environment variable `BABEL_ENV` with a fallback to the `NODE_ENV` environment variable. This can be set to a custom value to force cache busting if the identifier changes.
 

--- a/lib/fs-cache.js
+++ b/lib/fs-cache.js
@@ -11,6 +11,7 @@
  */
 var crypto = require('crypto');
 var mkdirp = require('mkdirp');
+var findCacheDir = require('find-cache-dir');
 var fs = require('fs');
 var os = require('os');
 var path = require('path');
@@ -126,7 +127,7 @@ var cache = module.exports = function(params, callback) {
   var identifier = params.identifier;
   var directory = (typeof params.directory === 'string') ?
         params.directory :
-        os.tmpdir();
+        findCacheDir({ name: 'babel-loader' });
   var file = path.join(directory, filename(source, identifier, options));
 
   // Make sure the directory exists.

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "lib"
   ],
   "dependencies": {
+    "find-cache-dir": "^0.1.1",
     "loader-utils": "^0.2.11",
     "mkdirp": "^0.5.1",
     "object-assign": "^4.0.1"

--- a/test/cache.test.js
+++ b/test/cache.test.js
@@ -12,6 +12,8 @@ var webpack = require('webpack');
 describe('Filesystem Cache', function() {
   this.timeout(15000);
 
+  var defaultCacheDir = path.resolve(__dirname,
+    '../node_modules/.cache/babel-loader');
   var cacheDir = path.resolve(__dirname, 'output/cache/cachefiles');
   var outputDir = path.resolve(__dirname, './output/cache/');
   var babelLoader = path.resolve(__dirname, '../');
@@ -43,6 +45,9 @@ describe('Filesystem Cache', function() {
       mkdirp(cacheDir, done);
     });
   });
+  beforeEach(function(done) {
+    rimraf(defaultCacheDir, done);
+  });
 
   it('should output files to cache directory', function(done) {
 
@@ -73,7 +78,7 @@ describe('Filesystem Cache', function() {
     });
   });
 
-  it('should output files to OS\'s tmp dir', function(done) {
+  it('should output files to standard cache dir by default', function(done) {
     var config = assign({}, globalConfig, {
       module: {
         loaders: [
@@ -93,7 +98,7 @@ describe('Filesystem Cache', function() {
     webpack(config, function(err, stats) {
       expect(err).to.be(null);
 
-      fs.readdir(os.tmpdir(), function(err, files) {
+      fs.readdir(defaultCacheDir, function(err, files) {
         files = files.filter(function(file) {
           return /\b[0-9a-f]{5,40}\.json\.gzip\b/.test(file);
         });


### PR DESCRIPTION
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?**
- [x] Bugfix

**What is the current behavior?**

Currently, when `cacheDirectory` is set to `true`, `babel-loader` tries to use the operating system's temporary directory as a cache directory.

However, when running npm scripts as the root user, [npm overrides the `TMPDIR` environment variable](https://github.com/npm/npm/issues/4531). This causes the cache files to be created in the project folder itself, for example when using Docker: facebookincubator/create-react-app#483.

**What is the new behavior?**

Use the [common cache directory](https://github.com/avajs/find-cache-dir), `./node_modules/.cache/babel-loader`, as the default cache directory (when the `cacheDirectory` setting is enabled).

**Does this PR introduce a breaking change?**
- [x] No
