### PR TITLE
Pin webpack version to v2.1.0-beta.22

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ node_js:
   - "5"
   - "4"
 env:
-  - export WEBPACK_VERSION="2.1.0-beta"
+  - export WEBPACK_VERSION="2.1.0-beta.22"
   - export WEBPACK_VERSION="1"
 matrix:
   fast_finish: true
@@ -20,7 +20,7 @@ before_install:
   - node --version
   - npm --version
 before_script:
-  - 'if [ "$WEBPACK_VERSION" ]; then npm install webpack@^$WEBPACK_VERSION; fi'
+  - 'if [ "$WEBPACK_VERSION" ]; then npm install webpack@$WEBPACK_VERSION; fi'
 script:
   - npm run travis
 after_success:


### PR DESCRIPTION
**Please Read the [CONTRIBUTING Guidelines](https://github.com/babel/babel-loader/blob/master/CONTRIBUTING.md)**
*In particular the portion on Commit Message Formatting*

**Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)

Failed the tests every time because webpackV2.1.0-beta.23(current: beta.25) was destructive change.
see: https://github.com/webpack/webpack/releases/tag/v2.1.0-beta.23

So we'll temporarily fix webpack version.

**What is the new behavior?**

CI is green.
However, we must apply to webpack version2.1.0 in the near future.

**Does this PR introduce a breaking change?**
- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the following...

* Impact:
* Migration path for existing applications:
* Github Issue(s) this is regarding:


**Other information**:

