### PR TITLE
fallback to os.tmpdir() if no cachedir found

### DIFF
--- a/lib/fs-cache.js
+++ b/lib/fs-cache.js
@@ -127,8 +127,11 @@ var cache = module.exports = function(params, callback) {
   var identifier = params.identifier;
   var directory;
 
-  if (typeof params.directory === 'string') directory = params.directory;
-  else directory = findCacheDir({ name: 'babel-loader' }) || os.tmpdir();
+  if (typeof params.directory === 'string') {
+    directory = params.directory;
+  } else {
+    directory = findCacheDir({ name: 'babel-loader' }) || os.tmpdir();
+  }
 
   var file = path.join(directory, filename(source, identifier, options));
 

--- a/lib/fs-cache.js
+++ b/lib/fs-cache.js
@@ -125,9 +125,11 @@ var cache = module.exports = function(params, callback) {
   var options = params.options || {};
   var transform = params.transform;
   var identifier = params.identifier;
-  var directory = (typeof params.directory === 'string') ?
-        params.directory :
-        findCacheDir({ name: 'babel-loader' });
+  var directory;
+  
+  if (typeof params.directory === 'string') directory = params.directory;
+  else directory = findCacheDir({ name: 'babel-loader' }) || os.tmpdir();
+  
   var file = path.join(directory, filename(source, identifier, options));
 
   // Make sure the directory exists.

--- a/lib/fs-cache.js
+++ b/lib/fs-cache.js
@@ -126,10 +126,10 @@ var cache = module.exports = function(params, callback) {
   var transform = params.transform;
   var identifier = params.identifier;
   var directory;
-  
+
   if (typeof params.directory === 'string') directory = params.directory;
   else directory = findCacheDir({ name: 'babel-loader' }) || os.tmpdir();
-  
+
   var file = path.join(directory, filename(source, identifier, options));
 
   // Make sure the directory exists.


### PR DESCRIPTION
Fix #317 by falling back to os.tmpdir()