### PR TITLE
Use babel to compile babel-loader

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,0 +1,5 @@
+{
+  "presets": [
+    ["latest", { "es2015": { "loose": true } }]
+  ]
+}

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+lib
 node_modules
 test/output
 coverage

--- a/.jscsrc
+++ b/.jscsrc
@@ -2,6 +2,7 @@
     "preset": "node-style-guide",
     "fileExtensions": [ ".js", "jscs" ],
     "excludeFiles": [
+        "lib/**",
         "test/fixtures/**",
         "test/output/**",
         "node_modules/**"

--- a/.jshintignore
+++ b/.jshintignore
@@ -1,2 +1,3 @@
+lib
 test/fixtures
 test/output

--- a/.jshintrc
+++ b/.jshintrc
@@ -1,5 +1,5 @@
 {
-  "strict": true,
+  "strict": false,
   "node": true,
   "mocha": true
 }

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,20 +1,14 @@
 sudo: false
 language: node_js
-os:
-  - linux
-  - osx
 node_js:
-  - node
   - "6"
   - "5"
   - "4"
+  - "0.12"
+  - "0.10"
 env:
   - export WEBPACK_VERSION="2.1.0-beta.22"
   - export WEBPACK_VERSION="1"
-matrix:
-  fast_finish: true
-  allow_failures:
-    - os: osx
 before_install:
   - nvm --version
   - node --version

--- a/package.json
+++ b/package.json
@@ -3,9 +3,9 @@
   "version": "6.2.7",
   "description": "babel module loader for webpack",
   "files": [
-    "index.js",
     "lib"
   ],
+  "main": "lib/index.js",
   "dependencies": {
     "find-cache-dir": "^0.1.1",
     "loader-utils": "^0.2.11",
@@ -17,7 +17,9 @@
     "webpack": "1 || ^2.1.0-beta"
   },
   "devDependencies": {
+    "babel-cli": "^6.18.0",
     "babel-core": "^6.0.0",
+    "babel-preset-latest": "^6.16.0",
     "babel-preset-es2015": "^6.0.0",
     "expect.js": "^0.3.1",
     "istanbul": "^0.4.0",
@@ -27,12 +29,14 @@
     "rimraf": "^2.4.3"
   },
   "scripts": {
-    "test": "npm run hint && npm run cs && npm run cover",
-    "travis": "npm run cover -- --report lcovonly",
+    "build": "babel src/ --out-dir lib/",
+    "test": "npm run build && npm run hint && npm run cs && npm run cover",
+    "travis": "npm run build && npm run cover -- --report lcovonly",
     "cover": "istanbul cover ./node_modules/.bin/_mocha -- test/*.test.js",
     "postcover": "npm run hint && npm run cs",
-    "hint": "jshint --config .jshintrc index.js lib/* test/*",
-    "cs": "jscs --config .jscsrc index.js lib/* test/*"
+    "prepublish": "npm run build",
+    "hint": "jshint --config .jshintrc src/* test/*",
+    "cs": "jscs --config .jscsrc src/* test/*"
   },
   "repository": {
     "type": "git",

--- a/src/fs-cache.js
+++ b/src/fs-cache.js
@@ -1,5 +1,3 @@
-'use strict';
-
 /**
  * Filesystem cache
  *

--- a/src/helpers/exists.js
+++ b/src/helpers/exists.js
@@ -1,5 +1,3 @@
-'use strict';
-
 var fs = require('fs');
 /**
  * Check if file exists and cache the result

--- a/src/helpers/read.js
+++ b/src/helpers/read.js
@@ -1,5 +1,3 @@
-'use strict';
-
 var fs = require('fs');
 /**
  * Read the file and cache the result

--- a/src/index.js
+++ b/src/index.js
@@ -1,14 +1,12 @@
-'use strict';
-
 var assign = require('object-assign');
 var babel = require('babel-core');
 var loaderUtils = require('loader-utils');
-var cache = require('./lib/fs-cache.js');
-var exists = require('./lib/helpers/exists')();
-var read = require('./lib/helpers/read')();
-var resolveRc = require('./lib/resolve-rc.js');
-var pkg = require('./package.json');
 var path = require('path');
+var cache = require('./fs-cache.js');
+var exists = require('./helpers/exists')();
+var read = require('./helpers/read')();
+var resolveRc = require('./resolve-rc.js');
+var pkg = require('./../package.json');
 
 /**
  * Error thrown by Babel formatted to conform to Webpack reporting.

--- a/src/resolve-rc.js
+++ b/src/resolve-rc.js
@@ -1,5 +1,3 @@
-'use strict';
-
 /**
  * The purpose of this module, is to find the project's .babelrc and
  * use its contents to bust the babel-loader's internal cache whenever an option


### PR DESCRIPTION
This does not break anything. and just moves `lib` to `src` and makes lib the destination of babel.
Preparation of eslint and using more es6.