### PR TITLE
gzipped files should have .gz as the extension, not .gzip

### DIFF
--- a/src/fs-cache.js
+++ b/src/fs-cache.js
@@ -80,7 +80,7 @@ const filename = function(source, identifier, options) {
 
   hash.end(contents);
 
-  return hash.read().toString("hex") + ".json.gzip";
+  return hash.read().toString("hex") + ".json.gz";
 };
 
 /**

--- a/test/cache.test.js
+++ b/test/cache.test.js
@@ -78,7 +78,7 @@ test.cb("should output files to cache directory", (t) => {
   });
 });
 
-test.cb.serial("should output files to standard cache dir by default", (t) => {
+test.cb.serial("should output <hash>.json.gz files to standard cache dir by default", (t) => {
   const config = assign({}, globalConfig, {
     output: {
       path: t.context.directory,
@@ -102,7 +102,7 @@ test.cb.serial("should output files to standard cache dir by default", (t) => {
     t.is(err, null);
 
     fs.readdir(defaultCacheDir, (err, files) => {
-      files = files.filter((file) => /\b[0-9a-f]{5,40}\.json\.gzip\b/.test(file));
+      files = files.filter((file) => /\b[0-9a-f]{5,40}\.json\.gz\b/.test(file));
 
       t.is(err, null);
       t.true(files.length > 0);


### PR DESCRIPTION
**Please Read the [CONTRIBUTING Guidelines](https://github.com/babel/babel-loader/blob/master/CONTRIBUTING.md)**
*In particular the portion on Commit Message Formatting*

**Please check if the PR fulfills these requirements**
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)
The standard extension for gzipped files is `.gz` but cachingDirectory causes files to be created with the extension `.gzip` 


**What is the new behavior?**
cache files are created with the extension `.gz`


**Does this PR introduce a breaking change?**
- [ ] Yes
- [x] No

