### PR TITLE
Feature: Passthru metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,58 @@ require('babel-runtime/core-js/promise').default = require('bluebird');
 require('./app');
 ```
 
+### using `cacheDirectory` fails with ENOENT Error
+
+If using cacheDirectory results in an error similar to the following:
+
+```
+ERROR in ./frontend/src/main.js
+Module build failed: Error: ENOENT, open 'true/350c59cae6b7bce3bb58c8240147581bfdc9cccc.json.gzip'
+ @ multi app
+```
+(notice the `true/` in the filepath)
+
+That means that most likely, you're not setting the options correctly, and you're doing something similar to:
+
+```javascript
+loaders: [
+  {
+    test: /\.jsx?$/,
+    exclude: /(node_modules|bower_components)/,
+    loader: 'babel?cacheDirectory=true'
+  }
+]
+```
+
+That's not the correct way of setting boolean values. You should do instead:
+
+```javascript
+loaders: [
+  {
+    test: /\.jsx?$/,
+    exclude: /(node_modules|bower_components)/,
+    loader: 'babel?cacheDirectory'
+  }
+]
+```
+
+or use the [query](https://webpack.github.io/docs/using-loaders.html#query-parameters) property:
+
+```javascript
+loaders: [
+  // the optional 'runtime' transformer tells babel to require the runtime
+  // instead of inlining it.
+  {
+    test: /\.jsx?$/,
+    exclude: /(node_modules|bower_components)/,
+    loader: 'babel',
+    query: {
+      cacheDirectory: true
+    }
+  }
+]
+```
+
 ### The node API for `babel` has been moved to `babel-core`.
 
 If you receive this message it means that you have the npm package `babel` installed and use the short notation of the loader in the webpack config (which is not valid anymore as of webpack 2.x):

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "babel-core": "^6.0.0",
     "babel-eslint": "^7.1.0",
     "babel-plugin-istanbul": "^3.0.0",
+    "babel-plugin-react-intl": "2.1.3",
     "babel-preset-es2015": "^6.0.0",
     "babel-preset-latest": "^6.16.0",
     "codecov": "^1.0.1",
@@ -31,6 +32,9 @@
     "eslint-plugin-babel": "^4.0.0",
     "eslint-plugin-flowtype": "^2.25.0",
     "nyc": "^9.0.0",
+    "react": "^15.1.0",
+    "react-intl":"^2.1.2",
+	"react-intl-webpack-plugin":"0.0.3",
     "rimraf": "^2.4.3",
     "webpack": "^2.1.0-beta.22"
   },

--- a/test/fixtures/metadata.js
+++ b/test/fixtures/metadata.js
@@ -1,0 +1,15 @@
+import {defineMessages} from 'react-intl';
+class App {
+  constructor(arg='test') {
+    var m = defineMessages({
+      greeting: {
+        id: 'greetingId',
+        defaultMessage: 'Hello World!'
+      },
+    });
+
+    this.result = arg;
+  }
+}
+
+export default App;

--- a/test/fixtures/metadataErr.js
+++ b/test/fixtures/metadataErr.js
@@ -1,0 +1,16 @@
+import {defineMessages} from 'react-intl';
+class App {
+  constructor(arg='test') {
+    var m = defineMessages({
+      greeting: {
+        id: 'greetingId',
+        defaultMessage: 'Hello World!'
+      },
+    });
+
+    bla bla
+    this.result = arg;
+  }
+}
+
+export default App;

--- a/test/metadata.test.js
+++ b/test/metadata.test.js
@@ -1,0 +1,137 @@
+"use strict";
+
+import fs from "fs";
+import path from "path";
+import assign from "object-assign";
+import test from "ava";
+import mkdirp from "mkdirp";
+import rimraf from "rimraf";
+import webpack from "webpack";
+import ReactIntlPlugin from "react-intl-webpack-plugin";
+
+const cacheDir = path.resolve(__dirname, "./output/cache/cachefiles");
+const outputDir = path.resolve(__dirname, "./output/metadata");
+const babelLoader = path.resolve(__dirname, "../");
+const globalConfig = {
+  entry: path.join(__dirname, "fixtures/metadata.js"),
+  output: {
+    path: outputDir,
+    filename: "[id].metadata.js",
+  },
+  plugins: [new ReactIntlPlugin(),],
+  module: {
+    loaders: [
+      {
+        test: /\.jsx?/,
+        loader: babelLoader,
+        query: {
+          metadataSubscribers: [ReactIntlPlugin.metadataContextFunctionName],
+          plugins: [
+            ["react-intl", {enforceDescriptions: false,},],
+          ],
+          presets: [],
+        },
+        exclude: /node_modules/,
+      },
+    ],
+  },
+};
+
+// Create a separate directory for each test so that the tests
+// can run in parallel
+test.cb.beforeEach((t) => {
+  const directory = path.join(outputDir, t.title.replace(/ /g, "_"));
+  t.context.directory = directory;
+  rimraf(directory, (err) => {
+    if (err) return t.end(err);
+    mkdirp(directory, t.end);
+  });
+});
+
+test.cb.afterEach((t) => rimraf(t.context.directory, t.end));
+
+test.cb("should pass metadata code snippet", function(t) {
+  const config = assign({}, globalConfig, {
+  });
+
+  webpack(config, function(err) {
+    t.is(err, null);
+
+    fs.readdir(outputDir, function(err) {
+      t.is(err, null);
+      fs.readFile(path.resolve(outputDir, "reactIntlMessages.json"),
+        function(err, data) {
+          const text = data.toString();
+          t.is(err, null);
+          const jsonText = JSON.parse(text);
+          t.is(jsonText.length, 1);
+          t.is(jsonText[0].id, "greetingId");
+          t.is(jsonText[0].defaultMessage, "Hello World!");
+
+          t.end();
+        });
+    });
+  });
+});
+
+test.cb("should not throw error ", function(t) {
+  const config = assign({}, globalConfig, {});
+
+  webpack(config, function(err, stats) {
+    t.is(stats.compilation.errors.length, 0);
+    t.end();
+  });
+});
+
+test.cb("should throw error ", function(t) {
+  const config = assign({}, globalConfig, {
+    entry: "./test/fixtures/metadataErr.js",
+  });
+
+  webpack(config, function(err, stats) {
+    t.true(stats.compilation.errors.length > 0);
+    t.end();
+  });
+});
+
+test.cb("should pass metadata code snippet (cache version)", function(t) {
+  const config = assign({}, globalConfig, {
+    module: {
+      loaders: [
+        {
+          test: /\.jsx?/,
+          loader: babelLoader,
+          query: {
+            metadataSubscribers:
+              [ReactIntlPlugin.metadataContextFunctionName],
+            plugins: [
+              ["react-intl", {enforceDescriptions: false,},],
+            ],
+            cacheDirectory: cacheDir,
+            presets: [],
+          },
+          exclude: /node_modules/,
+        },
+      ],
+    },
+  });
+
+  webpack(config, function(err) {
+    t.is(err, null);
+
+    fs.readdir(outputDir, function(err) {
+      t.is(err, null);
+      fs.readFile(path.resolve(outputDir, "reactIntlMessages.json"),
+        function(err, data) {
+          const text = data.toString();
+          t.is(err, null);
+          const jsonText = JSON.parse(text);
+          t.is(jsonText.length, 1);
+          t.is(jsonText[0].id, "greetingId");
+          t.is(jsonText[0].defaultMessage, "Hello World!");
+
+          t.end();
+        });
+    });
+  });
+});


### PR DESCRIPTION
**Please Read the [CONTRIBUTING Guidelines](https://github.com/babel/babel-loader/blob/master/CONTRIBUTING.md)**
*In particular the portion on Commit Message Formatting*

**Please check if the PR fulfills these requirements**
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)



**What is the new behavior?**

**note**: The following description was lifted from https://github.com/babel/babel-loader/pull/254#issue-157537604 from the original author @Ognian 

- add metadataSubscribers option as an array of context functions to call
- pass metadata to metadataSubscribers functions
- add .idea to .gitignore

This is needed when generating messages for translation from modules:

- there is the babel-react-intl plugin, which returns the messages it finds in the module in the metadata[react-int] property. (babel returns not only source code and source map but also the ast and the metadata property )
- since babel loader returns only source code and source map, I extended it to return metadata too. A webpack plugin is now able to aggregate all this metadata...


**Does this PR introduce a breaking change?**
- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the following...

* Impact:
* Migration path for existing applications:
* Github Issue(s) this is regarding:


**Other information**:
