### PR TITLE
Relative paths

### DIFF
--- a/src/utils/relative.js
+++ b/src/utils/relative.js
@@ -1,3 +1,5 @@
+const path = require("path");
+
 /**
 * Make a path relative to a URL or another path.
 * Borrowed from https://github.com/mozilla/source-map/blob/master/lib/util.js
@@ -8,6 +10,12 @@
 module.exports = function relative(aRoot, aPath) {
   if (aRoot === "") {
     aRoot = ".";
+  }
+  if (/^(?:[a-zA-Z]\:|\\\\[\w\.]+\\[\w.$]+)\\(?:[\w]+\\)*\w([\w.])+$/.test(aRoot)) {
+    // let Node take care of Windows paths
+    // regex from agent-j
+    // (http://stackoverflow.com/questions/6416065/c-sharp-regex-for-file-paths-e-g-c-test-test-exe)
+    return path.relative(aRoot, aPath);
   }
 
   aRoot = aRoot.replace(/\/$/, "");

--- a/src/utils/relative.js
+++ b/src/utils/relative.js
@@ -11,7 +11,7 @@ module.exports = function relative(aRoot, aPath) {
   if (aRoot === "") {
     aRoot = ".";
   }
-  if (/^(?:[a-zA-Z]\:|\\\\[\w\.]+\\[\w.$]+)/.test(aRoot)) {
+  if (/^(?:[a-zA-Z]\:|\\\\[\w\.]+\\[\w.$]+)/.test(aRoot) && path.win32) {
     // let Node take care of Windows paths
     // modified from regex by agent-j
     // (http://stackoverflow.com/questions/6416065/c-sharp-regex-for-file-paths-e-g-c-test-test-exe)

--- a/src/utils/relative.js
+++ b/src/utils/relative.js
@@ -15,7 +15,7 @@ module.exports = function relative(aRoot, aPath) {
     // let Node take care of Windows paths
     // modified from regex by agent-j
     // (http://stackoverflow.com/questions/6416065/c-sharp-regex-for-file-paths-e-g-c-test-test-exe)
-    return path.relative(aRoot, aPath);
+    return path.win32.relative(aRoot, aPath);
   }
 
   aRoot = aRoot.replace(/\/$/, "");

--- a/src/utils/relative.js
+++ b/src/utils/relative.js
@@ -11,9 +11,9 @@ module.exports = function relative(aRoot, aPath) {
   if (aRoot === "") {
     aRoot = ".";
   }
-  if (/^(?:[a-zA-Z]\:|\\\\[\w\.]+\\[\w.$]+)\\(?:[\w]+\\)*\w([\w.])+$/.test(aRoot)) {
+  if (/^(?:[a-zA-Z]\:|\\\\[\w\.]+\\[\w.$]+)/.test(aRoot)) {
     // let Node take care of Windows paths
-    // regex from agent-j
+    // modified from regex by agent-j
     // (http://stackoverflow.com/questions/6416065/c-sharp-regex-for-file-paths-e-g-c-test-test-exe)
     return path.relative(aRoot, aPath);
   }

--- a/test/utils/relative.test.js
+++ b/test/utils/relative.test.js
@@ -13,4 +13,7 @@ test("should get correct relative path", (t) => {
 
   t.is(relative("/", "/the/root/one.js"), "the/root/one.js");
   t.is(relative("/", "the/root/one.js"), "the/root/one.js");
+
+  t.is(relative("C:\\the\\root", "C:\\the\\root\\one.js"), "one.js");
+  t.is(relative("C:\\the", "C:\\the\\root\\one.js"), "root\\one.js");
 });

--- a/test/utils/relative.test.js
+++ b/test/utils/relative.test.js
@@ -16,4 +16,6 @@ test("should get correct relative path", (t) => {
 
   t.is(relative("C:\\the\\root", "C:\\the\\root\\one.js"), "one.js");
   t.is(relative("C:\\the", "C:\\the\\root\\one.js"), "root\\one.js");
+  t.is(relative("C:\\the\\root", "C:\\the\\one.js"), "..\\one.js");
+  t.is(relative("C:\\", "C:\\the\\root\\one.js"), "the\\root\\one.js");
 });


### PR DESCRIPTION
**Please Read the [CONTRIBUTING Guidelines](https://github.com/babel/babel-loader/blob/master/CONTRIBUTING.md)**
*In particular the portion on Commit Message Formatting*

**Please check if the PR fulfills these requirements**
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)
Right now, relative paths are calculated with POSIX in mind. When run on a Win32 platform, the relative path will fall back to creating an absolute path. In particular, line 23 in `lib/utils/relative.js` causes an error on platforms where paths are delimited by `\` (the `/` is not found, so index is -1, so `aPath` is immediately returned). 


**What is the new behavior?**
When presented with a Win32 style path, `relative.js` will call Node's `path.relative` to calculate a relative path.


**Does this PR introduce a breaking change?**
- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the following...

* Impact:
* Migration path for existing applications:
* Github Issue(s) this is regarding:


**Other information**:

