### PR TITLE
Make relative util work on windows

### DIFF
--- a/src/utils/relative.js
+++ b/src/utils/relative.js
@@ -1,39 +1,11 @@
-/**
-* Make a path relative to a URL or another path.
-* Borrowed from https://github.com/mozilla/source-map/blob/master/lib/util.js
-*
-* @param aRoot The root path or URL.
-* @param aPath The path or URL to be made relative to aRoot.
-*/
-module.exports = function relative(aRoot, aPath) {
-  if (aRoot === "") {
-    aRoot = ".";
+const path = require("path");
+
+module.exports = function relative(sourceRoot, filename) {
+  const rootPath = sourceRoot.split(path.sep)[1];
+  // If the file is in a completely different root folder use the absolute path of file.
+  if (rootPath && rootPath !== filename.split(path.sep)[1]) {
+    return filename;
   }
 
-  aRoot = aRoot.replace(/\/$/, "");
-
-  // It is possible for the path to be above the root. In this case, simply
-  // checking whether the root is a prefix of the path won't work. Instead, we
-  // need to remove components from the root one by one, until either we find
-  // a prefix that fits, or we run out of components to remove.
-  let level = 0;
-  while (aPath.indexOf(aRoot + "/") !== 0) {
-    const index = aRoot.lastIndexOf("/");
-    if (index < 0) {
-      return aPath;
-    }
-
-    // If the only part of the root that is left is the scheme (i.e. http://,
-    // file:///, etc.), one or more slashes (/), or simply nothing at all, we
-    // have exhausted all components, so the path is not relative to the root.
-    aRoot = aRoot.slice(0, index);
-    if (aRoot.match(/^([^\/]+:\/)?\/*$/)) {
-      return aPath;
-    }
-
-    ++level;
-  }
-
-  // Make sure we add a '../' for each component we removed from the root.
-  return Array(level + 1).join("../") + aPath.substr(aRoot.length + 1);
+  return path.relative(sourceRoot, filename);
 };

--- a/src/utils/relative.js
+++ b/src/utils/relative.js
@@ -1,9 +1,11 @@
 const path = require("path");
 
 module.exports = function relative(sourceRoot, filename) {
-  const rootPath = sourceRoot.split(path.sep)[1];
+  const rootPath = sourceRoot.replace(/\\/g, "/").split("/")[1];
+  const fileRootPath = filename.replace(/\\/g, "/").split("/")[1];
+
   // If the file is in a completely different root folder use the absolute path of file.
-  if (rootPath && rootPath !== filename.split(path.sep)[1]) {
+  if (rootPath && rootPath !== fileRootPath) {
     return filename;
   }
 

--- a/test/utils/relative.test.js
+++ b/test/utils/relative.test.js
@@ -1,23 +1,6 @@
 import test from "ava";
 import os from "os";
-import path from "path";
 import relative from "../../lib/utils/relative.js";
-
-test("should get correct relative path - depth 0", (t) => {
-  t.is(relative("/the/root", "/the/root/one.js"), "one.js");
-});
-
-test("should get correct relative path - depth 1", (t) => {
-  t.is(relative("/the/root", "/the/rootone.js"), `..${path.sep}rootone.js`);
-});
-
-test("should get correct relative path - depth 2", (t) => {
-  t.is(relative("/the/root", "/therootone.js"), `${path.sep}therootone.js`);
-});
-
-test("should get correct relative path with main root - depth 0", (t) => {
-  t.is(relative("/", "/the/root/one.js"), `the${path.sep}root${path.sep}one.js`);
-});
 
 if (os.platform() === "win32") {
   test("should get correct relative path - depth 0 - windows", (t) => {
@@ -34,5 +17,21 @@ if (os.platform() === "win32") {
 
   test("should get correct relative path with main root - depth 0 - windows", (t) => {
     t.is(relative("C:\\", "C:\\the\\root\\one.js"), "the\\root\\one.js");
+  });
+} else {
+  test("should get correct relative path - depth 0", (t) => {
+    t.is(relative("/the/root", "/the/root/one.js"), "one.js");
+  });
+
+  test("should get correct relative path - depth 1", (t) => {
+    t.is(relative("/the/root", "/the/rootone.js"), "../rootone.js");
+  });
+
+  test("should get correct relative path - depth 2", (t) => {
+    t.is(relative("/the/root", "/therootone.js"), "/therootone.js");
+  });
+
+  test("should get correct relative path with main root - depth 0", (t) => {
+    t.is(relative("/", "/the/root/one.js"), "the/root/one.js");
   });
 }

--- a/test/utils/relative.test.js
+++ b/test/utils/relative.test.js
@@ -1,16 +1,38 @@
 import test from "ava";
+import os from "os";
+import path from "path";
 import relative from "../../lib/utils/relative.js";
 
-test("should get correct relative path", (t) => {
+test("should get correct relative path - depth 0", (t) => {
   t.is(relative("/the/root", "/the/root/one.js"), "one.js");
-  t.is(relative("/the/root", "/the/rootone.js"), "../rootone.js");
-  t.is(relative("/the/root", "/therootone.js"), "/therootone.js");
-
-  t.is(relative("", "/the/root/one.js"), "/the/root/one.js");
-  t.is(relative(".", "/the/root/one.js"), "/the/root/one.js");
-  t.is(relative("", "the/root/one.js"), "the/root/one.js");
-  t.is(relative(".", "the/root/one.js"), "the/root/one.js");
-
-  t.is(relative("/", "/the/root/one.js"), "the/root/one.js");
-  t.is(relative("/", "the/root/one.js"), "the/root/one.js");
 });
+
+test("should get correct relative path - depth 1", (t) => {
+  t.is(relative("/the/root", "/the/rootone.js"), `..${path.sep}rootone.js`);
+});
+
+test("should get correct relative path - depth 2", (t) => {
+  t.is(relative("/the/root", "/therootone.js"), `${path.sep}therootone.js`);
+});
+
+test("should get correct relative path with main root - depth 0", (t) => {
+  t.is(relative("/", "/the/root/one.js"), `the${path.sep}root${path.sep}one.js`);
+});
+
+if (os.platform() === "win32") {
+  test("should get correct relative path - depth 0 - windows", (t) => {
+    t.is(relative("C:\\the\\root", "C:\\the\\root\\one.js"), "one.js");
+  });
+
+  test("should get correct relative path - depth 1 - windows", (t) => {
+    t.is(relative("C:\\the\\root", "C:\\the\\rootone.js"), "..\\rootone.js");
+  });
+
+  test("should get correct relative path - depth 2 - windows", (t) => {
+    t.is(relative("C:\\the\\root", "C:\\therootone.js"), "C:\\therootone.js");
+  });
+
+  test("should get correct relative path with main root - depth 0 - windows", (t) => {
+    t.is(relative("C:\\", "C:\\the\\root\\one.js"), "the\\root\\one.js");
+  });
+}


### PR DESCRIPTION
Fixes #334 
Fixes #339
Related #260 

This changes the relative util to work on windows. This basically reverts #260 and uses a different approach to fix #260 without breaking windows.