### PR TITLE
Add Webpack 2.2 RC as peerdependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   },
   "peerDependencies": {
     "babel-core": "^6.0.0",
-    "webpack": "1 || ^2.1.0-beta || ^2.2.0-rc.0"
+    "webpack": "1 || 2 || ^2.1.0-beta || ^2.2.0-rc"
   },
   "devDependencies": {
     "ava": "^0.17.0",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   },
   "peerDependencies": {
     "babel-core": "^6.0.0",
-    "webpack": "1 || ^2.1.0-beta"
+    "webpack": "1 || ^2.1.0-beta || ^2.2.0-rc.0"
   },
   "devDependencies": {
     "ava": "^0.17.0",


### PR DESCRIPTION
Fix for:
```sh
npm WARN babel-loader@6.2.9 requires a peer of webpack@1 || ^2.1.0-beta but none was installed.
```