### PR TITLE
Update loader-utils dependecy to ^0.2.16

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "main": "lib/index.js",
   "dependencies": {
     "find-cache-dir": "^0.1.1",
-    "loader-utils": "^0.2.11",
+    "loader-utils": "^0.2.16",
     "mkdirp": "^0.5.1",
     "object-assign": "^4.0.1"
   },


### PR DESCRIPTION
Anything below 0.2.16 for loader-utils causes issues with webpack 2 (https://github.com/webpack/webpack/issues/3060#issuecomment-249382018 and I have replicated the issue)

**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)

Webpack build fails with the error:

```
Module build failed: Error: parseQuery should get a string as first argument
    at Object.parseQuery (/path/to/node_modules/loader-utils/index.js:68:9)
    at Object.module.exports (/path/to/node_modules/babel-loader/lib/index.js:79:35)
```

**What is the new behavior?**

Webpack build succeeds

**Does this PR introduce a breaking change?**
- [ ] Yes
- [x] No