### PR TITLE
FS caching improvements

### DIFF
--- a/src/fs-cache.js
+++ b/src/fs-cache.js
@@ -15,6 +15,8 @@ const os = require("os");
 const path = require("path");
 const zlib = require("zlib");
 
+let defaultCacheDirectory = null;  // Lazily instantiated when needed
+
 /**
  * Read the contents from the compressed file.
  *
@@ -161,8 +163,6 @@ const handleCache = function(directory, params, callback) {
  *
  *   });
  */
-
-var defaultCacheDirectory = null;  // Lazily instantiated when needed
 
 module.exports = function(params, callback) {
   let directory;

--- a/src/fs-cache.js
+++ b/src/fs-cache.js
@@ -161,13 +161,19 @@ const handleCache = function(directory, params, callback) {
  *
  *   });
  */
+
+var defaultCacheDirectory = null;  // Lazily instantiated when needed
+
 module.exports = function(params, callback) {
   let directory;
 
   if (typeof params.directory === "string") {
     directory = params.directory;
   } else {
-    directory = findCacheDir({ name: "babel-loader" }) || os.tmpdir();
+    if (defaultCacheDirectory === null) {
+      defaultCacheDirectory = findCacheDir({ name: "babel-loader" }) || os.tmpdir();
+    }
+    directory = defaultCacheDirectory;
   }
 
   handleCache(directory, params, callback);

--- a/src/resolve-rc.js
+++ b/src/resolve-rc.js
@@ -10,6 +10,8 @@ const path = require("path");
 const exists = require("./utils/exists")({});
 const read = require("./utils/read")({});
 
+const cache = {};
+
 const find = function find(start, rel) {
   const file = path.join(start, rel);
 
@@ -27,6 +29,9 @@ const find = function find(start, rel) {
 
 module.exports = function(loc, rel) {
   rel = rel || ".babelrc";
-
-  return find(loc, rel);
+  const cacheKey = `${loc}/${rel}`;
+  if (!(cacheKey in cache)) {
+    cache[cacheKey] = find(loc, rel);
+  }
+  return cache[cacheKey];
 };


### PR DESCRIPTION
While tracking down the reason for some build slowness with [`--trace-sync-io`](https://github.com/nodejs/node/pull/1707), I found a couple file system hotspots that could use some caching.

* When using `cacheDirectory=true`, `findCacheDir` is repeatedly called, and it does some synchronous calls under the hood. However `findCacheDir` is more or less a pure function, so it's probably safe to call it once during process lifetime.
* `resolve-rc` has some caches for single `exists` and `read` operations, but there's still some more time that can be shaved off by simply memoizing the entire `resolve-rc` function.

These should not be breaking changes, _unless_ `.babelrc`files are created in intermediate directories during process lifetime, which sounds very unlikely.
