### PR TITLE
Apply forceEnv option to Babel transformation

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -78,6 +78,7 @@ module.exports = function(source, inputSourceMap) {
   const globalOptions = this.options.babel || {};
   const loaderOptions = loaderUtils.parseQuery(this.query);
   const userOptions = assign({}, globalOptions, loaderOptions);
+  const env = userOptions.forceEnv || process.env.BABEL_ENV || process.env.NODE_ENV;
   const defaultOptions = {
     inputSourceMap: inputSourceMap,
     sourceRoot: process.cwd(),
@@ -88,7 +89,7 @@ module.exports = function(source, inputSourceMap) {
       babelrc: exists(userOptions.babelrc) ?
           read(userOptions.babelrc) :
           resolveRc(path.dirname(filename)),
-      env: userOptions.forceEnv || process.env.BABEL_ENV || process.env.NODE_ENV,
+      env: env,
     }),
   };
 
@@ -129,6 +130,9 @@ module.exports = function(source, inputSourceMap) {
     });
   }
 
+  const tmpEnv = process.env.BABEL_ENV;
+  process.env.BABEL_ENV = env;
   result = transpile(source, options);
+  process.env.BABEL_ENV = tmpEnv;
   this.callback(null, result.code, result.map);
 };

--- a/test/loader.test.js
+++ b/test/loader.test.js
@@ -77,3 +77,43 @@ test.cb("should not throw error on syntax error", (t) => {
     t.end();
   });
 });
+
+test.cb("should use correct env", (t) => {
+  const config = {
+    entry: path.join(__dirname, "fixtures/basic.js"),
+    output: {
+      path: t.context.directory,
+    },
+    module: {
+      loaders: [
+        {
+          test: /\.jsx?/,
+          loader: babelLoader,
+          query: {
+            forceEnv: "testenv",
+            env: {
+              testenv: {
+                presets: ["es2015abc"],
+              },
+              otherenv: {
+                presets: ["es2015xyz"],
+              }
+            }
+          },
+          exclude: /node_modules/,
+        },
+      ],
+    },
+  };
+
+  webpack(config, (err, stats) => {
+    t.is(err, null);
+
+    t.true(stats.compilation.errors.length === 1);
+
+    t.truthy(stats.compilation.errors[0].message.match(/es2015abc/));
+    t.falsy(stats.compilation.errors[0].message.match(/es2015xyz/));
+
+    t.end();
+  });
+});


### PR DESCRIPTION
As per the discussion in #368, this PR applies the `forceEnv` option to the Babel transformation.

**Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix

**What is the current behavior?** (You can also link to an open issue here)
As discussed [here](https://github.com/babel/babel-loader/pull/368#issuecomment-279742678), the `forceEnv` option applies to the cacheIdentifier, but does not actually apply to the Babel transformation.

**What is the new behavior?**
The `forceEnv` option now applies to the Babel transformation as well.

**Does this PR introduce a breaking change?**
- [x] No