### PR TITLE
Bump loader-utils and use getOptions

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "main": "lib/index.js",
   "dependencies": {
     "find-cache-dir": "^0.1.1",
-    "loader-utils": "^0.2.16",
+    "loader-utils": "^1.0.2",
     "mkdirp": "^0.5.1",
     "object-assign": "^4.0.1"
   },

--- a/src/index.js
+++ b/src/index.js
@@ -76,7 +76,7 @@ module.exports = function(source, inputSourceMap) {
 
   // Handle options
   const globalOptions = this.options.babel || {};
-  const loaderOptions = loaderUtils.parseQuery(this.query);
+  const loaderOptions = loaderUtils.getOptions(this);
   const userOptions = assign({}, globalOptions, loaderOptions);
   const defaultOptions = {
     inputSourceMap: inputSourceMap,

--- a/yarn.lock
+++ b/yarn.lock
@@ -2627,6 +2627,14 @@ loader-utils@^0.2.11, loader-utils@^0.2.16:
     json5 "^0.5.0"
     object-assign "^4.0.1"
 
+loader-utils@^1.0.1:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/loader-utils/-/loader-utils-1.0.2.tgz#a9f923c865a974623391a8602d031137fad74830"
+  dependencies:
+    big.js "^3.1.3"
+    emojis-list "^2.0.0"
+    json5 "^0.5.0"
+
 lodash._baseassign@^3.0.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/lodash._baseassign/-/lodash._baseassign-3.2.0.tgz#8c38a099500f215ad09e59f1722fd0c52bfe0a4e"


### PR DESCRIPTION
Fixes warning:

```sh
DeprecationWarning: loaderUtils.parseQuery() received a non-string value which can be problematic, see https://github.com/webpack/loader-utils/issues/56
parseQuery() will be replaced with getOptions() in the next major version of loader-utils.
```

Ref: https://github.com/webpack/loader-utils/issues/56