### PR TITLE
fix deprecation warning

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -87,12 +87,11 @@ module.exports = function(source, inputSourceMap) {
 
   // Handle options
   const globalOptions = this.options.babel || {};
-  const loaderOptions = {};
   
   if ( loaderUtils.getOptions )
-    loaderOptions = loaderUtils.getOptions(this) || {};
+     const loaderOptions = loaderUtils.getOptions(this) || {};
   else
-    loaderUtils.parseQuery(this.query);
+     const loaderOptions = loaderUtils.parseQuery(this.query);
   
   const userOptions = assign({}, globalOptions, loaderOptions);
   const defaultOptions = {

--- a/src/index.js
+++ b/src/index.js
@@ -87,7 +87,13 @@ module.exports = function(source, inputSourceMap) {
 
   // Handle options
   const globalOptions = this.options.babel || {};
-  const loaderOptions = loaderUtils.getOptions ? loaderUtils.getOptions(this) || {} : loaderUtils.parseQuery(this.query);
+  const loaderOptions = {};
+  
+  if ( loaderUtils.getOptions )
+    loaderOptions = loaderUtils.getOptions(this) || {};
+  else
+    loaderUtils.parseQuery(this.query);
+  
   const userOptions = assign({}, globalOptions, loaderOptions);
   const defaultOptions = {
     inputSourceMap: inputSourceMap,

--- a/src/index.js
+++ b/src/index.js
@@ -87,7 +87,7 @@ module.exports = function(source, inputSourceMap) {
 
   // Handle options
   const globalOptions = this.options.babel || {};
-  const loaderOptions = loaderUtils.parseQuery(this.query);
+  const loaderOptions = loaderUtils.getOptions ? loaderUtils.getOptions(this) || {} : loaderUtils.parseQuery(this.query);
   const userOptions = assign({}, globalOptions, loaderOptions);
   const defaultOptions = {
     inputSourceMap: inputSourceMap,

--- a/src/index.js
+++ b/src/index.js
@@ -87,11 +87,7 @@ module.exports = function(source, inputSourceMap) {
 
   // Handle options
   const globalOptions = this.options.babel || {};
-  
-  if ( loaderUtils.getOptions )
-     const loaderOptions = loaderUtils.getOptions(this) || {};
-  else
-     const loaderOptions = loaderUtils.parseQuery(this.query);
+  const loaderOptions = loaderUtils.getOptions ? loaderUtils.getOptions(this) || {} : loaderUtils.parseQuery(this.query);
   
   const userOptions = assign({}, globalOptions, loaderOptions);
   const defaultOptions = {


### PR DESCRIPTION
Fixes deprecation warning for webpack 2.x+ while also keeps on working with older webpack versions.

DeprecationWarning: loaderUtils.parseQuery() received a non-string value which can be problematic, see (https://github.com/webpack/loader-utils/issues/56)[https://github.com/webpack/loader-utils/issues/56]

parseQuery() will be replaced with getOptions() in the next major version of loader-utils.

**Please Read the [CONTRIBUTING Guidelines](https://github.com/babel/babel-loader/blob/master/CONTRIBUTING.md)**
*In particular the portion on Commit Message Formatting*

**Please check if the PR fulfills these requirements**
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)



**What is the new behavior?**



**Does this PR introduce a breaking change?**
- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the following...

* Impact:
* Migration path for existing applications:
* Github Issue(s) this is regarding:


**Other information**:
