### PR TITLE
Feature/parse query deprecation

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "main": "lib/index.js",
   "dependencies": {
     "find-cache-dir": "^0.1.1",
-    "loader-utils": "^0.2.16",
+    "loader-utils": "^1.0.3",
     "mkdirp": "^0.5.1",
     "object-assign": "^4.0.1"
   },

--- a/src/index.js
+++ b/src/index.js
@@ -95,7 +95,7 @@ module.exports = function(source, inputSourceMap) {
 
   // Handle options
   const globalOptions = this.options.babel || {};
-  const loaderOptions = loaderUtils.parseQuery(this.query);
+  const loaderOptions = loaderUtils.getOptions(this);
   const userOptions = assign({}, globalOptions, loaderOptions);
   const defaultOptions = {
     metadataSubscribers: [],

--- a/yarn.lock
+++ b/yarn.lock
@@ -2699,6 +2699,14 @@ loader-utils@^0.2.16:
     json5 "^0.5.0"
     object-assign "^4.0.1"
 
+loader-utils@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/loader-utils/-/loader-utils-1.0.3.tgz#566c320c24c33cb3f02db4df83f3dbf60b253de3"
+  dependencies:
+    big.js "^3.1.3"
+    emojis-list "^2.0.0"
+    json5 "^0.5.0"
+
 lodash._baseassign@^3.0.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/lodash._baseassign/-/lodash._baseassign-3.2.0.tgz#8c38a099500f215ad09e59f1722fd0c52bfe0a4e"


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

loader-utils deprecated the use of `parseQuery(this.query)`. I just switched it to use the new accepted `getOptions(this)`.

**What is the current behavior?** (You can also link to an open issue here)
[Open Issue](https://github.com/babel/babel-loader/issues/415)


**What is the new behavior?**
No deprecation warning

**Does this PR introduce a breaking change?**
- [ ] Yes
- [x] No
