### PR TITLE
Fixed reset of BABEL_ENV when options.forceEnv is used

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -46,7 +46,7 @@ const transpile = function(source, options) {
   try {
     result = babel.transform(source, options);
   } catch (error) {
-    if (forceEnv) process.env.BABEL_ENV = tmpEnv;
+    if (forceEnv) restoreBabelEnv(tmpEnv);
     if (error.message && error.codeFrame) {
       let message = error.message;
       let name;
@@ -73,7 +73,7 @@ const transpile = function(source, options) {
     map.sourcesContent = [source];
   }
 
-  if (forceEnv) process.env.BABEL_ENV = tmpEnv;
+  if (forceEnv) restoreBabelEnv(tmpEnv);
 
   return {
     code: code,
@@ -81,6 +81,14 @@ const transpile = function(source, options) {
     metadata: metadata,
   };
 };
+
+function restoreBabelEnv(prevValue) {
+  if (prevValue === undefined) {
+    delete process.env.BABEL_ENV;
+  } else {
+    process.env.BABEL_ENV = prevValue;
+  }
+}
 
 function passMetadata(s, context, metadata) {
   if (context[s]) {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] Tests for the changes have been added (for bug fixes / features)

**What kind of change does this PR introduce?**
- [x] Bugfix

**What is the current behavior?** (You can also link to an open issue here)
After using 'forceEnv' option, BABEL_ENV is set to "undefined" (string), causing
unintended behaviour of babel running in different env.


**What is the new behavior?**
BABEL_ENV is correctly reset to previous value OR deleted if it wasn't set before


**Does this PR introduce a breaking change?**
- [ ] Yes
- [x] No


**Other**
Some new serial tests added to test the environment variable clearing. Serial is needed
because otherwise, parallel execution interfere with setting/clearing of the variable.
Maybe these tests could be done with less config - feel free to change/update them :)