### PR TITLE
Make sure .babelrc is a file, not a directory

### DIFF
--- a/src/utils/exists.js
+++ b/src/utils/exists.js
@@ -14,7 +14,7 @@ module.exports = function(cache) {
 
     if (!filename) { return false; }
 
-    cache[filename] = cache[filename] || fs.existsSync(filename);
+    cache[filename] = cache[filename] || (fs.existsSync(filename) && fs.statSync(filename).isFile());
 
     return cache[filename];
   };


### PR DESCRIPTION
**Please Read the [CONTRIBUTING Guidelines](https://github.com/babel/babel-loader/blob/master/CONTRIBUTING.md)**
*In particular the portion on Commit Message Formatting*

**Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)
If there is a _directory_ called `.babelrc` in the repo root or it's parent, the build breaks with an error: `Module build failed: Error: EISDIR: illegal operation on a directory, read` stemming from `find (/Users/hiroki/Documents/Gits/babel-loader/lib/resolve-rc.js:21:12)`


**What is the new behavior?**
If the detected `.babelrc` is not a file, it ignores it and moves on.


**Does this PR introduce a breaking change?**
- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the following...

* Impact:
* Migration path for existing applications:
* Github Issue(s) this is regarding:


**Other information**:
There is logic in `babel-core` in `build-config-chain.js` that checks if `.babelrc` exists but neglects to check if it's a file. I will make a PR fixing it there as well.