### PR TITLE
Support global options in LoaderOptionsPlugin

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -101,7 +101,8 @@ module.exports = function(source, inputSourceMap) {
   const filename = webpackRemainingChain[webpackRemainingChain.length - 1];
 
   // Handle options
-  const loaderOptions = loaderUtils.getOptions(this) || {};
+  const query = loaderUtils.getOptions(this) || {};
+  const loaderOptions = Object.assign({}, this.options.babel, query);
   const defaultOptions = {
     metadataSubscribers: [],
     inputSourceMap: inputSourceMap,


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)

babel-loader 7 does not accept global options defined in `webpack.LoaderOptionsPlugin`

**What is the new behavior?**

Just like babel-loader 6

**Does this PR introduce a breaking change?**
- [ ] Yes
- [x] No


**Other information**:

I don't know if you want to support this in babel-loader 7 though, feel free to close this if you don't.