### PR TITLE
Support watching of config files

### DIFF
--- a/src/resolve-rc.js
+++ b/src/resolve-rc.js
@@ -7,30 +7,24 @@
  * @see http://git.io/vLEvu
  */
 const path = require("path");
-const exists = require("./utils/exists")({});
-const read = require("./utils/read")({});
+const exists = require("./utils/exists");
 
-const cache = {};
-
-const find = function find(start, rel) {
+const findBabelrcPath = function find(fileSystem, start, rel) {
   const file = path.join(start, rel);
 
-  if (exists(file)) {
-    return read(file);
+  if (exists(fileSystem, file)) {
+    return file;
   }
 
   const up = path.dirname(start);
   if (up !== start) {
     // Reached root
-    return find(up, rel);
+    return find(fileSystem, up, rel);
   }
 };
 
-module.exports = function(loc, rel) {
+module.exports = function(fileSystem, loc, rel) {
   rel = rel || ".babelrc";
-  const cacheKey = `${loc}/${rel}`;
-  if (!(cacheKey in cache)) {
-    cache[cacheKey] = find(loc, rel);
-  }
-  return cache[cacheKey];
+
+  return findBabelrcPath(fileSystem, loc, rel);
 };

--- a/src/utils/exists.js
+++ b/src/utils/exists.js
@@ -1,22 +1,21 @@
-const fs = require("fs");
 /**
  * Check if file exists and cache the result
  * return the result in cache
  *
  * @example
- * var exists = require('./helpers/fsExists')({});
- * exists('.babelrc'); // false
+ * var exists = require('./helpers/fsExists');
+ * exists(require('fs'), '.babelrc'); // false
  */
-module.exports = function(cache) {
-  cache = cache || {};
+module.exports = function(fileSystem, filename) {
+  if (!filename) return false;
 
-  return function(filename) {
-    if (!filename) return false;
+  let exists = false;
 
-    cache[filename] =
-      cache[filename] ||
-      (fs.existsSync(filename) && fs.statSync(filename).isFile());
+  try {
+    exists = fileSystem.statSync(filename).isFile();
+  } catch (ignoreError) {
+    return false;
+  }
 
-    return cache[filename];
-  };
+  return exists;
 };

--- a/src/utils/read.js
+++ b/src/utils/read.js
@@ -1,22 +1,16 @@
-const fs = require("fs");
 /**
  * Read the file and cache the result
  * return the result in cache
  *
  * @example
- * var read = require('./helpers/fsExists')({});
- * read('.babelrc'); // file contents...
+ * var read = require('./helpers/fsExists');
+ * read(require('fs'), '.babelrc'); // file contents...
  */
-module.exports = function(cache) {
-  cache = cache || {};
+module.exports = function(fileSystem, filename) {
+  if (!filename) {
+    throw new Error("filename must be a string");
+  }
 
-  return function(filename) {
-    if (!filename) {
-      throw new Error("filename must be a string");
-    }
-
-    cache[filename] = cache[filename] || fs.readFileSync(filename, "utf8");
-
-    return cache[filename];
-  };
+  // Webpack `fs` return Buffer
+  return fileSystem.readFileSync(filename).toString("utf8");
 };

--- a/test/resolverc.test.js
+++ b/test/resolverc.test.js
@@ -1,10 +1,11 @@
 import test from "ava";
 import path from "path";
 import resolveRc from "../lib/resolve-rc.js";
+import fs from "fs";
 
 test("should find the .babelrc file", t => {
   const start = path.join(__dirname, "fixtures/babelrc-test/1/2/3");
-  const result = resolveRc(start);
+  const result = resolveRc(fs, start);
 
   t.true(typeof result === "string");
 });

--- a/test/utils/exists.test.js
+++ b/test/utils/exists.test.js
@@ -1,20 +1,17 @@
 import test from "ava";
 import path from "path";
 import exists from "../../lib/utils/exists.js";
+import fs from "fs";
 
-const cache = {};
-const files  = {
+const files = {
   existent: path.join(__dirname, "../fixtures/basic.js"),
   fake: path.join(__dirname, "../fixtures/nonExistentFile.js"),
 };
 
-test("should return boolean if file exists", (t) => {
-  const realFile = exists(cache)(files.existent);
-  const fakeFile = exists(cache)(files.fake);
+test("should return boolean if file exists", t => {
+  const realFile = exists(fs, files.existent);
+  const fakeFile = exists(fs, files.fake);
 
   t.true(realFile);
   t.false(fakeFile);
-
-  t.true(cache[files.existent]);
-  t.false(cache[files.fake]);
 });

--- a/test/utils/read.test.js
+++ b/test/utils/read.test.js
@@ -3,15 +3,13 @@ import fs from "fs";
 import path from "path";
 import read from "../../lib/utils/read.js";
 
-const cache = {};
-const files  = {
+const files = {
   existent: path.join(__dirname, "../fixtures/basic.js"),
 };
 
 const content = fs.readFileSync(files.existent, "utf8");
 
-test("should return contents if file exists", (t) => {
-  const realFile = read(cache)(files.existent);
+test("should return contents if file exists", t => {
+  const realFile = read(fs, files.existent);
   t.is(realFile, content);
-  t.is(cache[files.existent], content);
 });


### PR DESCRIPTION
**Please Read the [CONTRIBUTING Guidelines](https://github.com/babel/babel-loader/blob/master/CONTRIBUTING.md)**
*In particular the portion on Commit Message Formatting*

**Please check if the PR fulfills these requirements**
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)

Loader don't watch configuration files. Also don't adding configuration breaks other loader before `babel-loader`. And provide invalidate config after change.

**What is the new behavior?**

Watch on config files.

**Does this PR introduce a breaking change?**
- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the following...

* Impact:
* Migration path for existing applications:
* Github Issue(s) this is regarding:


**Other information**:
Ref: https://github.com/babel/babel-loader/pull/456#issuecomment-307143909
Ref: https://github.com/babel/babel-loader/pull/456#issuecomment-307161324