### PR TITLE
Do not read .babelrc for cache identifier when babelrc=false

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -111,9 +111,12 @@ module.exports = function(source, inputSourceMap) {
   // Handle options
   const loaderOptions = loaderUtils.getOptions(this) || {};
   const fileSystem = this.fs ? this.fs : fs;
-  const babelrcPath = exists(fileSystem, loaderOptions.babelrc)
-    ? loaderOptions.babelrc
-    : resolveRc(fileSystem, path.dirname(filename));
+  let babelrcPath = null;
+  if (loaderOptions.babelrc !== false) {
+    babelrcPath = exists(fileSystem, loaderOptions.babelrc)
+      ? loaderOptions.babelrc
+      : resolveRc(fileSystem, path.dirname(filename));
+  }
 
   if (babelrcPath) {
     this.addDependency(babelrcPath);


### PR DESCRIPTION
Fixes #464 