### PR TITLE
feat: Added warning when modules is not false (#477)

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -9,9 +9,8 @@ const resolveRc = require("./resolve-rc.js");
 const pkg = require("../package.json");
 const fs = require("fs");
 
-const presetsToCheckForModules = ["es2015", "env"];
-const modulesWarningMsg = `We've noticted the option modules isn't set to false,
-which disables treeshaking.`;
+// we keep track of each preset config
+const emitCache = new Map();
 
 /**
  * Error thrown by Babel formatted to conform to Webpack reporting.
@@ -165,12 +164,20 @@ module.exports = function(source, inputSourceMap) {
       }
 
       if (
-        presetsToCheckForModules.indexOf(name) > -1 &&
-        (!opts ||
-          (opts && !opts.hasOwnProperty("modules")) ||
-          (opts && opts.modules))
+        ["es2015", "env", "latest"].indexOf(name) > -1 &&
+        (!emitCache.has(options.presets) &&
+          (!opts ||
+            (opts && !opts.hasOwnProperty("modules")) ||
+            (opts && opts.modules)))
       ) {
-        this.emitWarning(new Error(modulesWarningMsg));
+        emitCache.set(options.presets, true);
+        this.emitWarning(
+          new Error(
+            `\n\n⚠️  Babel Loader\n
+It looks like your Babel configuration specifies a module transformer. Please disable it.
+See https://babeljs.io/docs/plugins/preset-${name}/#optionsmodules for more information.`,
+          ),
+        );
       }
     });
   }

--- a/src/index.js
+++ b/src/index.js
@@ -174,7 +174,8 @@ module.exports = function(source, inputSourceMap) {
         this.emitWarning(
           new Error(
             `\n\n⚠️  Babel Loader\n
-It looks like your Babel configuration specifies a module transformer. Please disable it.
+It looks like your Babel configuration specifies a module transformer.
+This disables tree shaking in webpack and will produce larger bundles. Please disable it.
 See https://babeljs.io/docs/plugins/preset-${name}/#optionsmodules for more information.`,
           ),
         );

--- a/test/loader.test.js
+++ b/test/loader.test.js
@@ -263,3 +263,39 @@ test.cb("should not throw without config", t => {
     t.end();
   });
 });
+
+test.cb("should throw a warning when modules is set to false", t => {
+  const config = {
+    entry: path.join(__dirname, "fixtures/basic.js"),
+    output: {
+      path: t.context.directory,
+    },
+    module: {
+      loaders: [
+        {
+          test: /\.jsx?/,
+          loader: babelLoader,
+          exclude: /node_modules/,
+          query: {
+            presets: [["env", { modules: "umd" }]],
+          },
+        },
+      ],
+    },
+  };
+
+  webpack(config, (err, stats) => {
+    t.is(err, null);
+
+    const warnings = stats.compilation.warnings;
+    t.true(warnings.length > 0);
+    if (warnings.length) {
+      t.is(
+        warnings[0].message,
+        "We've noticted the option modules isn't set to false,\nwhich disables treeshaking.",
+      );
+    }
+
+    t.end();
+  });
+});

--- a/test/loader.test.js
+++ b/test/loader.test.js
@@ -321,7 +321,8 @@ test.cb("should throw a warning when modules is not set to false", t => {
         t.is(
           warnings[0].message,
           `\n\n⚠️  Babel Loader\n
-It looks like your Babel configuration specifies a module transformer. Please disable it.
+It looks like your Babel configuration specifies a module transformer.
+This disables tree shaking in webpack and will produce larger bundles. Please disable it.
 See https://babeljs.io/docs/plugins/preset-${presetName}/#optionsmodules for more information.`,
         );
       }


### PR DESCRIPTION
**Please Read the [CONTRIBUTING Guidelines](https://github.com/babel/babel-loader/blob/master/CONTRIBUTING.md)**
*In particular the portion on Commit Message Formatting*

**Please check if the PR fulfills these requirements**
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)
#477 


**What is the new behavior?**
When webpack is version 2 or higher and we're using es2015 or env preset
We throw a warning saying that webpack can't treeshake correctly


**Does this PR introduce a breaking change?**
- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the following...

* Impact: Users with not having the right configs on webpack2 will get a warning
* Migration path for existing applications: 
* Github Issue(s) this is regarding: #477 


**Other information**:
