### PR TITLE
babelrc-related bugfixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "babel-loader",
-  "version": "7.1.1",
+  "version": "7.1.2",
   "description": "babel module loader for webpack",
   "files": [
     "lib"

--- a/src/index.js
+++ b/src/index.js
@@ -112,7 +112,7 @@ module.exports = function(source, inputSourceMap) {
   const loaderOptions = loaderUtils.getOptions(this) || {};
   const fileSystem = this.fs ? this.fs : fs;
   let babelrcPath = null;
-  if (loaderOptions.babelrc !== false) {
+  if (loaderOptions.babelrc) {
     babelrcPath = exists(fileSystem, loaderOptions.babelrc)
       ? loaderOptions.babelrc
       : resolveRc(fileSystem, path.dirname(filename));

--- a/src/utils/exists.js
+++ b/src/utils/exists.js
@@ -1,9 +1,9 @@
-module.exports = function(fileSystem, filename) {
-  let exists = false;
-
+module.exports = function exists (fileSystem, filename) {
   try {
-    exists = fileSystem.statSync(filename).isFile();
-  } catch (e) {}
-
-  return exists;
-};
+    return fileSystem.statSync(filename).isFile()
+  }
+  catch (err) {
+    if (err.code === 'ENOENT') return false
+    throw err
+  }
+}


### PR DESCRIPTION
* don't try to load missing babelrc (`false` check was too narrow)
* don't swallow non-FS errors when checking if file exists