### PR TITLE
Do not swallow errors in exists() and only call exists if option is  string

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -113,7 +113,8 @@ module.exports = function(source, inputSourceMap) {
   const fileSystem = this.fs ? this.fs : fs;
   let babelrcPath = null;
   if (loaderOptions.babelrc !== false) {
-    babelrcPath = exists(fileSystem, loaderOptions.babelrc)
+    babelrcPath = typeof loaderOptions.babelrc === "string" &&
+      exists(fileSystem, loaderOptions.babelrc)
       ? loaderOptions.babelrc
       : resolveRc(fileSystem, path.dirname(filename));
   }

--- a/src/utils/exists.js
+++ b/src/utils/exists.js
@@ -3,7 +3,9 @@ module.exports = function(fileSystem, filename) {
 
   try {
     exists = fileSystem.statSync(filename).isFile();
-  } catch (e) {}
+  } catch (err) {
+    if (err.code !== "ENOENT") throw err;
+  }
 
   return exists;
 };

--- a/test/utils/exists.test.js
+++ b/test/utils/exists.test.js
@@ -15,3 +15,8 @@ test("should return boolean if file exists", t => {
   t.true(realFile);
   t.false(fakeFile);
 });
+
+test("should rethrow errors besides ENOENT", t => {
+  t.throws(() => exists(fs, false), /path must be a string/);
+  t.throws(() => exists(fs, undefined), /path must be a string/);
+});


### PR DESCRIPTION
Fix for #494 
