### PR TITLE
Add the message in BabelLoaderError's stack trace

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -14,12 +14,13 @@ const fs = require("fs");
  */
 function BabelLoaderError(name, message, codeFrame, hideStack, error) {
   Error.call(this);
-  Error.captureStackTrace(this, BabelLoaderError);
 
   this.name = "BabelLoaderError";
   this.message = formatMessage(name, message, codeFrame);
   this.hideStack = hideStack;
   this.error = error;
+
+  Error.captureStackTrace(this, BabelLoaderError);
 }
 
 BabelLoaderError.prototype = Object.create(Error.prototype);

--- a/test/loader.test.js
+++ b/test/loader.test.js
@@ -263,3 +263,21 @@ test.cb("should not throw without config", t => {
     t.end();
   });
 });
+
+test.cb(
+  "should return compilation errors with the message included in the stack trace",
+  t => {
+    const config = Object.assign({}, globalConfig, {
+      entry: path.join(__dirname, "fixtures/syntax.js"),
+      output: {
+        path: t.context.directory,
+      },
+    });
+    webpack(config, (err, stats) => {
+      const moduleBuildError = stats.compilation.errors[0];
+      const babelLoaderError = moduleBuildError.error;
+      t.regex(babelLoaderError.stack, /Unexpected character/);
+      t.end();
+    });
+  },
+);


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?**

When a BabelLoaderError is thrown on Node 8.x, the `message` is not included in the `stack` property. When webpack wraps the error in a ModuleBuildError, the `message` is lost from webpack's output:

```
ERROR in ./entry.js
Module build failed: Error
    at transpile (/Users/stephen/t/node_modules/babel-loader/lib/index.js:64:13)
    at Object.module.exports (/Users/stephen/t/node_modules/babel-loader/lib/index.js:174:20)
```


**What is the new behavior?**

The BabelLoaderError's `message` is included in the `stack` property, so even after wrapping in a ModuleBuildError, the error message and the code where the error occurred are visible.

```
ERROR in ./entry.js
Module build failed: /Users/stephen/t/entry.js: Reference to undeclared variable "foo"

> 1 | foo()
    | ^
  2 |
Error
    at transpile (/Users/stephen/t/node_modules/babel-loader/lib/index.js:64:13)
    at Object.module.exports (/Users/stephen/t/node_modules/babel-loader/lib/index.js:174:20)
```

**Does this PR introduce a breaking change?**
- [ ] Yes
- [X] No


**Other information**:

I had first thought this was [a webpack issue](https://github.com/webpack/webpack/pull/5499), but they suggested this was something the loader should change.

I think the behavior of Error.captureStackTrace may have changed between Node versions, because this behavior appeared when I upgraded from Node 6.x to 8.x. Perhaps the old behavior was to not read the `message` property until `stack` was read, and the new behavior is to read `message` immediately? I have not had time to verify this, though, this is just speculation.

This is the `webpack.config.js` I was using to create the error messages above (entry.js simply contains the text `foo()`):

```js
var path = require('path')

module.exports = {
  entry: path.join(__dirname, 'entry.js'),

  output: {
    filename: 'output.js'
  },

  module: {
    rules: [
      {
        test: /\.js$/,
        use: {
          loader: 'babel-loader',
          options: {
            plugins: ['babel-plugin-undeclared-variables-check']
          }
        }
      }
    ]
  }
}
```