### PR TITLE
fix compatibility with @babel/core option check when inputSourceMap null

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -127,7 +127,7 @@ module.exports = function(source, inputSourceMap) {
 
   const defaultOptions = {
     metadataSubscribers: [],
-    inputSourceMap: inputSourceMap,
+    inputSourceMap: inputSourceMap || undefined,
     sourceRoot: process.cwd(),
     filename: filename,
     cacheIdentifier: JSON.stringify({


### PR DESCRIPTION
**Please Read the [CONTRIBUTING Guidelines](https://github.com/babel/babel-loader/blob/master/CONTRIBUTING.md)**
*In particular the portion on Commit Message Formatting*

**Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)
Assertion in @babel/core package when file come from another loader without sourceMap
In my case `val-loader` with only `code` option.
https://github.com/babel/babel/blob/master/packages/babel-core/src/config/option-assertions.js#L71


**What is the new behavior?**
No errors on compilation.


**Does this PR introduce a breaking change?**
- [ ] Yes
- [x] No

**Other information**:
