### PR TITLE
Allow any version of webpack as a peerDependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   },
   "peerDependencies": {
     "@babel/core": "7 || ^7.0.0-beta || ^7.0.0-rc",
-    "webpack": "*"
+    "webpack": ">=2"
   },
   "devDependencies": {
     "@babel/cli": "7.0.0-beta.5",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   },
   "peerDependencies": {
     "@babel/core": "7 || ^7.0.0-beta || ^7.0.0-rc",
-    "webpack": "2 || 3"
+    "webpack": "*"
   },
   "devDependencies": {
     "@babel/cli": "7.0.0-beta.5",


### PR DESCRIPTION
Webpack 4 alpha has been released. In preparation for v4,
it seems reasonable to change this to allow `*`. This should cut
down on maintenance and avoid unnecessarily blocking folks
from updating going forward.

**Please Read the [CONTRIBUTING Guidelines](https://github.com/babel/babel-loader/blob/master/CONTRIBUTING.md)**
*In particular the portion on Commit Message Formatting*

**Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Other... Please describe: peerDependency change

**What is the current behavior?** (You can also link to an open issue here)
Cannot be used with Webpack 4 alpha


**What is the new behavior?**
Can be used with Webpack 4 alpha


**Does this PR introduce a breaking change?**
- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the following...

* Impact:
* Migration path for existing applications:
* Github Issue(s) this is regarding:


**Other information**:
It would be nice to put out a release of babel-loader that allows any version of webpack and also works with Babel 6.