### PR TITLE
Make compressing transforms cache configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-> This readme is for babel-loader v8 + Babel v7  
+> This readme is for babel-loader v8 + Babel v7
 > Check the [7.x branch](https://github.com/babel/babel-loader/tree/7.x) for docs with Babel v6
 
 [![NPM Status](https://img.shields.io/npm/v/babel-loader.svg?style=flat)](https://www.npmjs.com/package/babel-loader)
@@ -87,6 +87,8 @@ This loader also supports the following loader-specific option:
 * `cacheDirectory`: Default `false`. When set, the given directory will be used to cache the results of the loader. Future webpack builds will attempt to read from the cache to avoid needing to run the potentially expensive Babel recompilation process on each run. If the value is blank (`loader: 'babel-loader?cacheDirectory'`) or `true` (`loader: babel-loader?cacheDirectory=true`) the loader will use the default cache directory in `node_modules/.cache/babel-loader` or fallback to the default OS temporary file directory if no `node_modules` folder could be found in any root directory.
 
 * `cacheIdentifier`: Default is a string composed by the babel-core's version, the babel-loader's version, the contents of .babelrc file if it exists and the value of the environment variable `BABEL_ENV` with a fallback to the `NODE_ENV` environment variable. This can be set to a custom value to force cache busting if the identifier changes.
+
+* `cacheCompression`: Default `true`. When set, each Babel transform output will be compressed with Gzip. If you want to opt-out of cache compression, set it to `false` -- your project may benefit from this if it transpiles thousands of files.
 
 __Note:__ The `sourceMap` option is ignored, instead sourceMaps are automatically enabled when webpack is configured to use them (via the `devtool` config option).
 

--- a/src/index.js
+++ b/src/index.js
@@ -94,6 +94,7 @@ async function loader(source, inputSourceMap, overrides) {
   // Remove loader related options
   delete programmaticOptions.cacheDirectory;
   delete programmaticOptions.cacheIdentifier;
+  delete programmaticOptions.cacheCompression;
   delete programmaticOptions.metadataSubscribers;
 
   if (!babel.loadPartialConfig) {
@@ -121,6 +122,7 @@ async function loader(source, inputSourceMap, overrides) {
         "@babel/core": transform.version,
         "@babel/loader": pkg.version,
       }),
+      cacheCompression = true,
       metadataSubscribers = [],
     } = loaderOptions;
 
@@ -132,6 +134,7 @@ async function loader(source, inputSourceMap, overrides) {
         transform,
         cacheDirectory,
         cacheIdentifier,
+        cacheCompression,
       });
     } else {
       result = await transform(source, options);

--- a/test/cache.test.js
+++ b/test/cache.test.js
@@ -120,6 +120,43 @@ test.cb.serial(
 );
 
 test.cb.serial(
+  "should output non-compressed files to standard cache dir when cacheCompression is set to false",
+  t => {
+    const config = Object.assign({}, globalConfig, {
+      output: {
+        path: t.context.directory,
+      },
+      module: {
+        rules: [
+          {
+            test: /\.jsx?/,
+            loader: babelLoader,
+            exclude: /node_modules/,
+            options: {
+              cacheDirectory: true,
+              cacheCompression: false,
+              presets: ["@babel/preset-env"],
+            },
+          },
+        ],
+      },
+    });
+
+    webpack(config, err => {
+      t.is(err, null);
+
+      fs.readdir(defaultCacheDir, (err, files) => {
+        files = files.filter(file => /\b[0-9a-f]{5,40}\b/.test(file));
+
+        t.is(err, null);
+        t.true(files.length > 0);
+        t.end();
+      });
+    });
+  },
+);
+
+test.cb.serial(
   "should output files to standard cache dir if set to true in query",
   t => {
     const config = Object.assign({}, globalConfig, {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] Tests for the changes have been added
- [x] Docs have been updated

**What kind of change does this PR introduce?**
- [x] Feature

**What is the current behavior?**
Cache compression is mandatory


**What is the new behavior?**
One can opt out from compressing cache using the new `cacheCompression: boolean` option. 
By default set to `true` so it doesn't break anything.


**Does this PR introduce a breaking change?**
- [x] No

* Impact: couple % faster builds for large projects (1k+ transpiled files)
* Github Issue(s) this is regarding: Resolves #571 


**Other information**:
I wrote a bit about in related issue #571 