### PR TITLE
Use .babelrc when options.babelrc path is supplied

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -121,8 +121,14 @@ module.exports = function(source, inputSourceMap) {
         : resolveRc(fileSystem, path.dirname(filename));
   }
 
+  let babelRcOptions = null;
   if (babelrcPath) {
     this.addDependency(babelrcPath);
+    try {
+      babelRcOptions = JSON.parse(read(fileSystem, babelrcPath));
+    } catch (e) {
+      babelRcOptions = {};
+    }
   }
 
   const defaultOptions = {
@@ -142,7 +148,12 @@ module.exports = function(source, inputSourceMap) {
     }),
   };
 
-  const options = Object.assign({}, defaultOptions, loaderOptions);
+  const options = Object.assign(
+    {},
+    defaultOptions,
+    babelRcOptions,
+    loaderOptions,
+  );
 
   if (loaderOptions.sourceMap === undefined) {
     options.sourceMap = this.sourceMap;


### PR DESCRIPTION
**Please Read the [CONTRIBUTING Guidelines](https://github.com/babel/babel-loader/blob/master/CONTRIBUTING.md)**
*In particular the portion on Commit Message Formatting*

**Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

Some help writing this test would be very much appreciated.

**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
- [x] Bugfix

**What is the current behavior?** (You can also link to an open issue here)
Doesn't read the babelrc file when path is supplied.


**What is the new behavior?**
Reads the babelrc file and applies the configuration that's passed on to `transpile`. If configuration is supplied within the loader options, that takes precedence even if babelrc  path is supplied.


**Does this PR introduce a breaking change?**
- [x] No

If this PR contains a breaking change, please describe the following...

* Impact:
* Migration path for existing applications:
* Github Issue(s) this is regarding: https://github.com/babel/babel-loader/issues/552


**Other information**:
