### PR TITLE
Set `babelrc` option to `true` by default

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -117,11 +117,11 @@ module.exports = function(source, inputSourceMap) {
   const fileSystem = this.fs ? this.fs : fs;
   let babelrcPath = null;
   if (loaderOptions.babelrc !== false) {
-    babelrcPath =
-      typeof loaderOptions.babelrc === "string" &&
-      exists(fileSystem, loaderOptions.babelrc)
-        ? loaderOptions.babelrc
-        : resolveRc(fileSystem, path.dirname(filename));
+    if (typeof loaderOptions.babelrc === "string" && exists(fileSystem, loaderOptions.babelrc)) {
+      babelrcPath = loaderOptions.babelrc;
+    } else {
+      babelrcPath = resolveRc(fileSystem, path.dirname(filename));
+    }
   }
 
   if (babelrcPath) {

--- a/src/index.js
+++ b/src/index.js
@@ -110,7 +110,10 @@ module.exports = function(source, inputSourceMap) {
   const filename = webpackRemainingChain[webpackRemainingChain.length - 1];
 
   // Handle options
-  const loaderOptions = loaderUtils.getOptions(this) || {};
+  const loaderOptions = Object.assign({ }, {
+    babelrc: true
+  }, loaderUtils.getOptions(this) || { });
+  
   const fileSystem = this.fs ? this.fs : fs;
   let babelrcPath = null;
   if (loaderOptions.babelrc !== false) {


### PR DESCRIPTION
**Please Read the [CONTRIBUTING Guidelines](https://github.com/babel/babel-loader/blob/master/CONTRIBUTING.md)**
*In particular the portion on Commit Message Formatting*

**Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
- [X] Bugfix (#552)
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)

As reported in #552, `babel-loader` does not respect `.babelrc`, `.babelrc.js` or the `babel` property of `package.json` like `babel` does normally. 

**What is the new behavior?**

Defaulting the `babelrc` option to `true` signals `babel-loader` to scan for `.babelrc` et al as expected.

**Does this PR introduce a breaking change?**
- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the following...

* Impact:
* Migration path for existing applications:
* Github Issue(s) this is regarding:


**Other information**:
