### PR TITLE
Correct plugin name is @babel/plugin-transform-runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ rules: [
       loader: 'babel-loader',
       options: {
         presets: ['@babel/preset-env'],
-        plugins: ['@babel/transform-runtime']
+        plugins: ['@babel/plugin-transform-runtime']
       }
     }
   }


### PR DESCRIPTION
Rename `@babel/transform-runtime` to `@babel/plugin-transform-runtime` in the example

**Please Read the [CONTRIBUTING Guidelines](https://github.com/babel/babel-loader/blob/master/CONTRIBUTING.md)**
*In particular the portion on Commit Message Formatting*

**Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been updated

**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Other... Please describe: Docs update

**What is the current behavior?** (You can also link to an open issue here)



**What is the new behavior?**



**Does this PR introduce a breaking change?**
- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the following...

* Impact:
* Migration path for existing applications:
* Github Issue(s) this is regarding:


**Other information**:

In the code example there is wrong plugin name used. Should be `@babel/plugin-transform-runtime` instead of `@babel/transform-runtime`