### PR TITLE
use modules false to enable webpack tree shaking

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,9 @@ module: {
         loader: 'babel-loader',
         options: {
           presets: [['@babel/preset-env', { modules: false }]]
+          // you need set modules: false in order to get tree shaking working
+          // by default preset-env transpiles modules to commonjs but webpack supports ES6 modules
+          // see https://new.babeljs.io/docs/en/next/babel-preset-env.html#modules
         }
       }
     }

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ module: {
       use: {
         loader: 'babel-loader',
         options: {
-          presets: ['@babel/preset-env']
+          presets: [['@babel/preset-env', { modules: false }]]
         }
       }
     }
@@ -73,7 +73,7 @@ module: {
       use: {
         loader: 'babel-loader',
         options: {
-          presets: ['@babel/preset-env'],
+          presets: [['@babel/preset-env', { modules: false }]],
           plugins: [require('@babel/plugin-proposal-object-rest-spread')]
         }
       }

--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ rules: [
     use: {
       loader: 'babel-loader',
       options: {
-        presets: ['@babel/preset-env'],
+        presets: [['@babel/preset-env', { modules: false }]],
         plugins: ['@babel/plugin-transform-runtime']
       }
     }


### PR DESCRIPTION
by default all modules are transpiled to `commonjs` therefore they cannot be statically analysed and tree shaking will not work

see https://stackoverflow.com/questions/45384170/how-to-fix-modules-with-moduleconcatenation-bailout-module-is-not-an-ecmascrip