### PR TITLE
Return full result from `babel.transform`.

### DIFF
--- a/src/transform.js
+++ b/src/transform.js
@@ -14,13 +14,18 @@ module.exports = async function(source, options) {
 
   if (!result) return null;
 
-  const { code, map, metadata } = result;
+  // We don't return the full result here because some entries are not
+  // really serializable. For a full list of properties see here:
+  // https://github.com/babel/babel/blob/master/packages/babel-core/src/transformation/index.js
+  // For discussion on this topic see here:
+  // https://github.com/babel/babel-loader/pull/629
+  const { ast, code, map, metadata, sourceType } = result;
 
   if (map && (!map.sourcesContent || !map.sourcesContent.length)) {
     map.sourcesContent = [source];
   }
 
-  return { code, map, metadata };
+  return { ast, code, map, metadata, sourceType };
 };
 
 module.exports.version = babel.version;


### PR DESCRIPTION
Previous code only returns an object of the shape `{ code, map, metadata }` which prevents accessing things like the AST when `babel` is configured to output it. This change allows access to more things that `babel` spits out.

**Please check if the PR fulfills these requirements**
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)

Returns only `{ code, map, metadata }`.

**What is the new behavior?**

Returns more result data (`ast` and `sourceType`).

**Does this PR introduce a breaking change?**
- [ ] Yes
- [x] No