### PR TITLE
Avoid absolute paths in cache filename hashes

### DIFF
--- a/src/fs-cache.js
+++ b/src/fs-cache.js
@@ -72,9 +72,31 @@ const write = function(filename, result, callback) {
  */
 const filename = function(source, identifier, options) {
   const hash = crypto.createHash("md4");
+
+  // By default, options will look something like:
+  //
+  // {
+  //   inputSourceMap: undefined,
+  //   sourceRoot: '/abs/path/to/project',
+  //   filename: '/abs/path/to/project/src/index.js',
+  //   sourceMap: false,
+  //   sourceFileName: 'src/index.js',
+  // }
+  //
+  // The absolute paths here are problematic when running this on production
+  // build machines that persist this cache but also have different absolute
+  // paths. Since the source filename has enough unique information here about
+  // the cached file, and it is a relative version of the filename, we can
+  // improve this by removing the absolute paths from the options before
+  // hashing.
+  const processedOptions = Object.assign({}, options, {
+    sourceRoot: null,
+    filename: null,
+  });
+
   const contents = JSON.stringify({
     source: source,
-    options: options,
+    options: processedOptions,
     identifier: identifier,
   });
 


### PR DESCRIPTION
By default, options will look something like:

```js
{
  inputSourceMap: undefined,
  sourceRoot: '/abs/path/to/project',
  filename: '/abs/path/to/project/src/index.js',
  sourceMap: false,
  sourceFileName: 'src/index.js',
}
```

The absolute paths here are problematic when running this on production
build machines that persist this cache but also have different absolute
paths. In this scenario, this causes the cache to be useless, and to
grow in size exceptionally fast.

Since the source filename has enough unique information here about
the cached file, and it is a relative version of the filename, we can
improve this by removing the absolute paths from the options before
hashing.

**Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)

At Airbnb, we are using babel-loader with the cacheDirectory option turned on. For our production builds, we persist this cache across builds. However, each build is run on a different machine in a random temp directory. And, since the absolute paths are currently part of the cache filename hash, this causes the cache to be unused and leads to problems with the cache growing in size too quickly.

**What is the new behavior?**

In this PR, I am removing the absolute paths from the options object before stringifying and hashing.

**Does this PR introduce a breaking change?**
- [ ] Yes
- [x] No

**Other information**:

I think this should effectively resolve #634.

I wrote this PR against the 7.x branch in hopes that we could get it into a 7.x release. If you think this is a good approach, I am happy to open a similar PR against master.

Also, I didn't see an easy way to write a test for this, so if you have any suggestions on that front, please let me know!