### PR TITLE
Use md4 instead of sha1 for filename hashes

### DIFF
--- a/src/fs-cache.js
+++ b/src/fs-cache.js
@@ -71,16 +71,16 @@ const write = function(filename, result, callback) {
  * @return {String}
  */
 const filename = function(source, identifier, options) {
-  const hash = crypto.createHash("SHA1");
+  const hash = crypto.createHash("md4");
   const contents = JSON.stringify({
     source: source,
     options: options,
     identifier: identifier,
   });
 
-  hash.end(contents);
+  hash.update(contents);
 
-  return hash.read().toString("hex") + ".json.gz";
+  return hash.digest("hex") + ".json.gz";
 };
 
 /**


### PR DESCRIPTION
We don't need the cryptographic strength of SHA-1 for this purpose, so
we may as well use a faster hashing algorithm.

While I was at it, I also sapped out the use of hash.end + hash.read
combo for the faster and more conventional hash.update + hash.digest. In
my local testing, this also seems to offer a nice speed boost.

**Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)

Uses SHA-1 for cache filename hash.

**What is the new behavior?**

Uses MD4 for cache filename hash.

**Does this PR introduce a breaking change?**
- [ ] Yes
- [x] No

**Other information**:

I wrote this PR against the 7.x branch in hopes that we could get it into a 7.x release. If you think this is a good approach, I am happy to open a similar PR against master.