### PR TITLE
Use MD4 instead of SHA1 for filename hashes

### DIFF
--- a/src/cache.js
+++ b/src/cache.js
@@ -62,13 +62,13 @@ const write = async function(filename, result) {
  * @return {String}
  */
 const filename = function(source, identifier, options) {
-  const hash = crypto.createHash("SHA1");
+  const hash = crypto.createHash("md4");
 
   const contents = JSON.stringify({ source, options, identifier });
 
-  hash.end(contents);
+  hash.update(contents);
 
-  return hash.read().toString("hex") + ".json.gz";
+  return hash.digest("hex") + ".json.gz";
 };
 
 /**


### PR DESCRIPTION
We don't need the cryptographic strength of SHA-1 for this purpose, so
we may as well use a faster hashing algorithm.

While I was at it, I also sapped out the use of hash.end + hash.read
combo for the faster and more conventional hash.update + hash.digest. In
my local testing, this also seems to offer a nice speed boost.

This is the same as #638 but on the 8.x (master) branch.