### PR TITLE
Read file before creating directory

### DIFF
--- a/src/cache.js
+++ b/src/cache.js
@@ -80,6 +80,14 @@ const filename = function(source, identifier, options) {
 const handleCache = async function(directory, params) {
   const { source, options = {}, cacheIdentifier, cacheDirectory } = params;
 
+  const file = path.join(directory, filename(source, cacheIdentifier, options));
+
+  try {
+    // No errors mean that the file was previously cached
+    // we just need to return it
+    return await read(file);
+  } catch (err) {}
+
   const fallback =
     typeof cacheDirectory !== "string" && directory !== os.tmpdir();
 
@@ -93,14 +101,6 @@ const handleCache = async function(directory, params) {
 
     throw err;
   }
-
-  const file = path.join(directory, filename(source, cacheIdentifier, options));
-
-  try {
-    // No errors mean that the file was previously cached
-    // we just need to return it
-    return await read(file);
-  } catch (err) {}
 
   // Otherwise just transform the file
   // return it to the user asap and write it in cache


### PR DESCRIPTION
After spending some time debugging where babel-loader compile time goes I found out that it tries to run mkdirp to create the cache directory for every possible file that's passed to babel-loader. This change makes sure that it only tries to create the directory if something has to be written to it.

This is still not ideal as it tries to create the directory for every file that's not there (this can take from 0 to 50ms per file from benchmarks I ran on a relatively large app (220 webpack entrypoints and around 1000 components)).

The most performant solution is keeping track of directories that were already created using a `new Set()`, but that seems to fail the tests as after every test the directory is removed and the internal cache remains.