### PR TITLE
Resolve presets if resolveLoader.modules is set (7.x)

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -148,6 +148,14 @@ module.exports = function(source, inputSourceMap) {
     options.sourceFileName = relative(options.sourceRoot, options.filename);
   }
 
+  if (options.presets !== undefined) {
+    options.presets = loaderOptions.presets.map(function(preset) {
+      return typeof preset === "string"
+        ? require.resolve(`babel-preset-${preset}`)
+        : [require.resolve(`babel-preset-${preset[0]}`), preset[1]];
+    });
+  }
+
   const cacheDirectory = options.cacheDirectory;
   const cacheIdentifier = options.cacheIdentifier;
   const metadataSubscribers = options.metadataSubscribers;


### PR DESCRIPTION
If `resolveLoader.modules` is specified, it is ignored for presets (see #166 ). This fixes the problem by resolving the presets first. 

I'm not 100% sure this is the way it should be fixed, but this fix works for our React Native project where all our dependencies and loaders are not in the same directory as the sources. We're still running React Native 55.x, which uses Babel 6, hence the fix on version 7.x. If the patch is accepted, we'll open one for 8.x (as we're in the process of upgrading React Native and Babel).