### PR TITLE
Add `modules: false` by default for es2015/env/latest presets

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -85,6 +85,28 @@ async function loader(source, inputSourceMap, overrides) {
     );
   }
 
+  if (this.version > 1 && programmaticOptions.presets) {
+    programmaticOptions.presets.forEach((preset, i) => {
+      let name = preset;
+      let opts = {};
+      if (Array.isArray(preset)) {
+        name = preset[0];
+        opts = preset[1];
+      }
+      if (
+        ["env", "babel-preset-env", "@babel/preset-env"].includes(name) &&
+        (!opts || (opts && !opts.hasOwnProperty("modules")))
+      ) {
+        const newOpts = { modules: false };
+        if (Array.isArray(preset)) {
+          preset[1] = Object.assign({}, opts, newOpts);
+        } else {
+          programmaticOptions.presets[i] = [name, newOpts];
+        }
+      }
+    });
+  }
+
   const config = babel.loadPartialConfig(programmaticOptions);
   if (config) {
     let options = config.options;

--- a/src/index.js
+++ b/src/index.js
@@ -87,18 +87,15 @@ async function loader(source, inputSourceMap, overrides) {
 
   if (this.version > 1 && programmaticOptions.presets) {
     programmaticOptions.presets.forEach((preset, i) => {
-      let name = preset;
-      let opts = {};
-      if (Array.isArray(preset)) {
-        name = preset[0];
-        opts = preset[1];
-      }
+      const presetIsArray = Array.isArray(preset);
+      const name = presetIsArray ? preset[0] : preset;
+      const opts = presetIsArray ? preset[1] : {};
       if (
         ["env", "babel-preset-env", "@babel/preset-env"].includes(name) &&
         (!opts || (opts && !opts.hasOwnProperty("modules")))
       ) {
         const newOpts = { modules: false };
-        if (Array.isArray(preset)) {
+        if (presetIsArray) {
           preset[1] = Object.assign({}, opts, newOpts);
         } else {
           programmaticOptions.presets[i] = [name, newOpts];


### PR DESCRIPTION
**Note** this is an update version of PR #529.

**Please check if the PR fulfills these requirements**
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)

See #521.

**What is the new behavior?**

The Babel presets `env`, `latest` and `es2015` will be mutated to add `modules: false` as an option. This also works when you use e.g. `@babel/preset-env` or `@babel/env`.

**Does this PR introduce a breaking change?**
- [x] Yes
- [ ] No

For people who use babel-loader without setting the `modules` option, there might be small differences in the way webpack handles ES modules.

For people who still want to keep the old behavior, they can explicitly add `modules: true` or e.g. `modules: "amd"`.

**Other information**:

I am not happy at all with the implementation, but it works. Let me know if there is a better way I missed.

I used parts of the code in #485, so credits to @wardpeet!

Fixes #521, fixes #477, fixes #485