### PR TITLE
Added option for custom cache hash behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,13 @@ This loader also supports the following loader-specific option:
 
 * `cacheIdentifier`: Default is a string composed by the babel-core's version, the babel-loader's version, the contents of .babelrc file if it exists and the value of the environment variable `BABEL_ENV` with a fallback to the `NODE_ENV` environment variable. This can be set to a custom value to force cache busting if the identifier changes.
 
+* `modifyCacheHash`: Default `undefined`. When setted, will invokes as  
+`function(source, options, cacheIdentifier) -> Object|String` where  
+`String source` - module's code;  
+`Object options` - united options of loader;  
+`String cacheIdentifier` - see above.  
+Allows to modify contents, that will use for creating a hash for cached resources. Returned value then will be stringified.   It can be useful if your builds are deploying on Heroku and a build directory is dynamic (for example `/tmp/build<random-hash>/`). In this case, we should exclude the absolute build path from the hash string to hit cache stored by Heroku.
+
 * `babelrc`: Default `true`. When `false`, no options from `.babelrc` files will be used; only the options passed to
 `babel-loader` will be used.
 

--- a/src/cache.js
+++ b/src/cache.js
@@ -174,6 +174,7 @@ const handleCache = async function(directory, params) {
 
 module.exports = async function(params) {
   let directory;
+
   if (typeof params.cacheDirectory === "string") {
     directory = params.cacheDirectory;
   } else {

--- a/src/index.js
+++ b/src/index.js
@@ -74,6 +74,7 @@ async function loader(source, inputSourceMap, overrides) {
   });
   // Remove loader related options
   delete programmaticOptions.cacheDirectory;
+  delete programmaticOptions.modifyCacheHash;
   delete programmaticOptions.cacheIdentifier;
   delete programmaticOptions.metadataSubscribers;
 
@@ -97,6 +98,7 @@ async function loader(source, inputSourceMap, overrides) {
 
     const {
       cacheDirectory = null,
+      modifyCacheHash = null,
       cacheIdentifier = JSON.stringify({
         options,
         "@babel/core": transform.version,
@@ -111,6 +113,7 @@ async function loader(source, inputSourceMap, overrides) {
         source,
         options,
         transform,
+        modifyCacheHash,
         cacheDirectory,
         cacheIdentifier,
       });


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
- [ ] Bugfix
- [x] Feature
- [x] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?**

No option for setting custom cache hash behavior

**What is the new behavior?**

Added option for setting custom cache hash behavior.
```
const fields = {
  filename: 1,
  sourceRoot: 1,
  dirname: 1,
  resolved: 1,
  cwd: 1
};
...
modifyCacheHash: (source, options, cacheIdentifier) => {
  const convertedOptions = JSON.stringify(options, (key, value) => {
    if (fields[key]) {
      return undefined;
    }
    return value;
  });
  return source + convertedOptions + cacheIdentifier;
}
...
```

**Does this PR introduce a breaking change?**
- [ ] Yes
- [x] No

**Other information:**

It can be useful if your builds are deploying on Heroku and a build directory is dynamic (for example `/tmp/build<random-hash>/`). In this case, we should exclude the absolute build path from the hash string to hit cache stored by Heroku.
