### PR TITLE
Make preset-env skip CommonJS compilation by default, so that Webpack itself can handle it.

### DIFF
--- a/src/transform.js
+++ b/src/transform.js
@@ -7,7 +7,7 @@ const transform = promisify(babel.transform);
 module.exports = async function(source, options) {
   let result;
   try {
-    result = await transform(source, options);
+    result = await transform(source, injectCaller(options));
   } catch (err) {
     throw err.message && err.codeFrame ? new LoaderError(err) : err;
   }
@@ -29,3 +29,43 @@ module.exports = async function(source, options) {
 };
 
 module.exports.version = babel.version;
+
+function injectCaller(opts) {
+  if (!supportsCallerOption()) return opts;
+
+  return Object.assign({}, opts, {
+    caller: Object.assign(
+      {
+        name: "babel-loader",
+
+        // Webpack >= 2 supports ESM and dynamic import.
+        supportsStaticESM: true,
+        supportsDynamicImport: true,
+      },
+      opts.caller,
+    ),
+  });
+}
+
+// TODO: We can remove this eventually, I'm just adding it so that people have
+// a little time to migrate to the newer RCs of @babel/core without getting
+// hard-to-diagnose errors about unknown 'caller' options.
+let supportsCallerOptionFlag = undefined;
+function supportsCallerOption() {
+  if (supportsCallerOptionFlag === undefined) {
+    try {
+      // Rather than try to match the Babel version, we just see if it throws
+      // when passed a 'caller' flag, and use that to decide if it is supported.
+      babel.loadPartialConfig({
+        caller: undefined,
+        babelrc: false,
+        configFile: false,
+      });
+      supportsCallerOptionFlag = true;
+    } catch (err) {
+      supportsCallerOptionFlag = false;
+    }
+  }
+
+  return supportsCallerOptionFlag;
+}


### PR DESCRIPTION
**What is the new behavior?**

With https://github.com/babel/babel/pull/8485, Babel 7.x now supports a `caller` option which can pass in metadata about the execution environment.

This PR enables the `supportsStaticESM` flag, which means that `preset-env` will automatically default to outputting ES modules instead of automatically converting files to CommonJS.

