### PR TITLE
Remove babelrc from loader-specific options

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,9 +88,6 @@ This loader also supports the following loader-specific option:
 
 * `cacheIdentifier`: Default is a string composed by the babel-core's version, the babel-loader's version, the contents of .babelrc file if it exists and the value of the environment variable `BABEL_ENV` with a fallback to the `NODE_ENV` environment variable. This can be set to a custom value to force cache busting if the identifier changes.
 
-* `babelrc`: Default `true`. When `false`, no options from `.babelrc` files will be used; only the options passed to
-`babel-loader` will be used.
-
 __Note:__ The `sourceMap` option is ignored, instead sourceMaps are automatically enabled when webpack is configured to use them (via the `devtool` config option).
 
 ## Troubleshooting


### PR DESCRIPTION
`babelrc` is [supported by Babel](https://babeljs.io/docs/en/options#babelrc), so it is not a loader-specific option.

**Please check if the PR fulfills these requirements**
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Other... Please describe: Docs update

**What is the current behavior?** (You can also link to an open issue here)

/

**What is the new behavior?**

/

**Does this PR introduce a breaking change?**
- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the following...

* Impact: /
* Migration path for existing applications: /
* Github Issue(s) this is regarding: /


**Other information**:
