### PR TITLE
Add a warning if you forget to install @babel/core or install babel-core.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,23 @@
-const babel = require("@babel/core");
+let babel;
+try {
+  babel = require("@babel/core");
+} catch (err) {
+  if (err.code === "MODULE_NOT_FOUND") {
+    err.message +=
+      "\n babel-loader@8 requires Babel 7.x (the package '@babel/core'). " +
+      "If you'd like to use Babel 6.x ('babel-core'), you should install 'babel-loader@7'.";
+  }
+  throw err;
+}
+
+// Since we've got the reverse bridge package at @babel/core@6.x, give
+// people useful feedback if they try to use it alongside babel-loader.
+if (/^6\./.test(babel.version)) {
+  throw new Error(
+    "\n babel-loader@8 will not work with the '@babel/core@6' bridge package. " +
+      "If you want to use Babel 6.x, install 'babel-loader@7'.",
+  );
+}
 
 const pkg = require("../package.json");
 const cache = require("./cache");


### PR DESCRIPTION
I'd assume that issues like #8599 will be common until people get used to the new naming scheme, so we should do our best to help them.