### PR TITLE
Use 'sourceMaps' since that is what we suggest to use in our docs.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -75,16 +75,29 @@ async function loader(source, inputSourceMap, overrides) {
     );
   }
 
+  // Standardize on 'sourceMaps' as the key passed through to Webpack, so that
+  // users may safely use either one alongside our default use of
+  // 'this.sourceMap' below without getting error about conflicting aliases.
+  if (
+    Object.prototype.hasOwnProperty.call(loaderOptions, "sourceMap") &&
+    !Object.prototype.hasOwnProperty.call(loaderOptions, "sourceMaps")
+  ) {
+    loaderOptions = Object.assign({}, loaderOptions, {
+      sourceMaps: loaderOptions.sourceMap,
+    });
+    delete loaderOptions.sourceMap;
+  }
+
   const programmaticOptions = Object.assign({}, loaderOptions, {
     filename,
     inputSourceMap: inputSourceMap || undefined,
 
     // Set the default sourcemap behavior based on Webpack's mapping flag,
     // but allow users to override if they want.
-    sourceMap:
-      loaderOptions.sourceMap === undefined
+    sourceMaps:
+      loaderOptions.sourceMaps === undefined
         ? this.sourceMap
-        : loaderOptions.sourceMap,
+        : loaderOptions.sourceMaps,
 
     // Ensure that Webpack will get a full absolute path in the sourcemap
     // so that it can properly map the module back to its internal cached

--- a/test/sourcemaps.test.js
+++ b/test/sourcemaps.test.js
@@ -121,3 +121,97 @@ test.cb("should output webpack's devtoolModuleFilename option", t => {
     });
   });
 });
+
+test.only.cb("should disable sourcemap output with 'sourceMaps:true'", t => {
+  const config = Object.assign({}, globalConfig, {
+    devtool: "source-map",
+    output: {
+      path: t.context.directory,
+    },
+    module: {
+      rules: [
+        {
+          test: /\.jsx?/,
+          loader: babelLoader + "?presets[]=@babel/env&sourceMaps=false",
+          exclude: /node_modules/,
+        },
+      ],
+    },
+  });
+
+  webpack(config, (err, stats) => {
+    t.is(err, null);
+    t.is(stats.compilation.errors.length, 0);
+    t.is(stats.compilation.warnings.length, 0);
+
+    fs.readdir(t.context.directory, (err, files) => {
+      t.is(err, null);
+
+      const map = files.filter(file => file.indexOf(".map") !== -1);
+
+      t.true(map.length > 0);
+
+      if (map.length > 0) {
+        fs.readFile(path.resolve(t.context.directory, map[0]), (err, data) => {
+          t.is(err, null);
+
+          const mapObj = JSON.parse(data.toString());
+          t.is(mapObj.sources[1], "webpack:///./test/fixtures/basic.js");
+
+          // Ensure that the code contains Babel's compiled output, because
+          // sourcemaps from Babel are disabled.
+          t.not(mapObj.sourcesContent[1].indexOf("__esModule"), -1);
+
+          t.end();
+        });
+      }
+    });
+  });
+});
+
+test.only.cb("should disable sourcemap output with 'sourceMap:true'", t => {
+  const config = Object.assign({}, globalConfig, {
+    devtool: "source-map",
+    output: {
+      path: t.context.directory,
+    },
+    module: {
+      rules: [
+        {
+          test: /\.jsx?/,
+          loader: babelLoader + "?presets[]=@babel/env&sourceMap=false",
+          exclude: /node_modules/,
+        },
+      ],
+    },
+  });
+
+  webpack(config, (err, stats) => {
+    t.is(err, null);
+    t.is(stats.compilation.errors.length, 0);
+    t.is(stats.compilation.warnings.length, 0);
+
+    fs.readdir(t.context.directory, (err, files) => {
+      t.is(err, null);
+
+      const map = files.filter(file => file.indexOf(".map") !== -1);
+
+      t.true(map.length > 0);
+
+      if (map.length > 0) {
+        fs.readFile(path.resolve(t.context.directory, map[0]), (err, data) => {
+          t.is(err, null);
+
+          const mapObj = JSON.parse(data.toString());
+          t.is(mapObj.sources[1], "webpack:///./test/fixtures/basic.js");
+
+          // Ensure that the code contains Babel's compiled output, because
+          // sourcemaps from Babel are disabled.
+          t.not(mapObj.sourcesContent[1].indexOf("__esModule"), -1);
+
+          t.end();
+        });
+      }
+    });
+  });
+});


### PR DESCRIPTION
Fixes #658

Babel allows both 'sourceMap' and 'sourceMaps'. Not only were we using the wrong one (because our docs recommend 'sourceMaps', but we were also causing Babel to _always_ throw an unhelpful error when the user used the wrong one.