### PR TITLE
showcase sample configs with respect to .mjs

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Within your webpack configuration object, you'll need to add the babel-loader to
 module: {
   rules: [
     {
-      test: /\.js$/,
+      test: /\.(js|mjs)$/,
       exclude: /(node_modules|bower_components)/,
       use: {
         loader: 'babel-loader',
@@ -68,7 +68,7 @@ You can pass options to the loader by using the [`options`](https://webpack.js.o
 module: {
   rules: [
     {
-      test: /\.js$/,
+      test: /\.(js|mjs)$/,
       exclude: /(node_modules|bower_components)/,
       use: {
         loader: 'babel-loader',
@@ -119,7 +119,7 @@ rules: [
   // the 'transform-runtime' plugin tells Babel to
   // require the runtime instead of inlining it.
   {
-    test: /\.js$/,
+    test: /\.(js|mjs)$/,
     exclude: /(node_modules|bower_components)/,
     use: {
       loader: 'babel-loader',
@@ -183,7 +183,7 @@ require('./app');
 If you receive this message, it means that you have the npm package `babel` installed and are using the short notation of the loader in the webpack config (which is not valid anymore as of webpack 2.x):
 ```javascript
   {
-    test: /\.js$/,
+    test: /\.(js|mjs)$/,
     loader: 'babel',
   }
 ```
@@ -194,7 +194,7 @@ To fix this, you should uninstall the npm package `babel`, as it is deprecated i
 In the case one of your dependencies is installing `babel` and you cannot uninstall it yourself, use the complete name of the loader in the webpack config:
 ```javascript
   {
-    test: /\.js$/,
+    test: /\.(js|mjs)$/,
     loader: 'babel-loader',
   }
 ```


### PR DESCRIPTION
as mentioned https://twitter.com/capajj/status/1042836215022735361 we need to transpile .mjs files as well. Having this regex like this by default will save countless developers from wondering why their bundle has fat arrows and other ES6 features.

**Please Read the [CONTRIBUTING Guidelines](https://github.com/babel/babel-loader/blob/master/CONTRIBUTING.md)**
*In particular the portion on Commit Message Formatting*

**Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Other... Please describe: documentation improvement

**What is the current behavior?** (You can also link to an open issue here)



**What is the new behavior?**



**Does this PR introduce a breaking change?**
- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the following...

* Impact:
* Migration path for existing applications:
* Github Issue(s) this is regarding:


**Other information**:
please ask if anything is unclear, I'll gladly try to explain more.