### PR TITLE
Also pass the caller option to loadPartialConfig

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -22,6 +22,7 @@ if (/^6\./.test(babel.version)) {
 const pkg = require("../package.json");
 const cache = require("./cache");
 const transform = require("./transform");
+const injectCaller = require("./injectCaller");
 
 const loaderUtils = require("loader-utils");
 
@@ -118,7 +119,7 @@ async function loader(source, inputSourceMap, overrides) {
     );
   }
 
-  const config = babel.loadPartialConfig(programmaticOptions);
+  const config = babel.loadPartialConfig(injectCaller(programmaticOptions));
   if (config) {
     let options = config.options;
     if (overrides && overrides.config) {

--- a/src/injectCaller.js
+++ b/src/injectCaller.js
@@ -1,0 +1,41 @@
+const babel = require("@babel/core");
+
+module.exports = function injectCaller(opts) {
+  if (!supportsCallerOption()) return opts;
+
+  return Object.assign({}, opts, {
+    caller: Object.assign(
+      {
+        name: "babel-loader",
+
+        // Webpack >= 2 supports ESM and dynamic import.
+        supportsStaticESM: true,
+        supportsDynamicImport: true,
+      },
+      opts.caller,
+    ),
+  });
+};
+
+// TODO: We can remove this eventually, I'm just adding it so that people have
+// a little time to migrate to the newer RCs of @babel/core without getting
+// hard-to-diagnose errors about unknown 'caller' options.
+let supportsCallerOptionFlag = undefined;
+function supportsCallerOption() {
+  if (supportsCallerOptionFlag === undefined) {
+    try {
+      // Rather than try to match the Babel version, we just see if it throws
+      // when passed a 'caller' flag, and use that to decide if it is supported.
+      babel.loadPartialConfig({
+        caller: undefined,
+        babelrc: false,
+        configFile: false,
+      });
+      supportsCallerOptionFlag = true;
+    } catch (err) {
+      supportsCallerOptionFlag = false;
+    }
+  }
+
+  return supportsCallerOptionFlag;
+}

--- a/src/transform.js
+++ b/src/transform.js
@@ -1,14 +1,13 @@
 const babel = require("@babel/core");
 const promisify = require("util.promisify");
 const LoaderError = require("./Error");
-const injectCaller = require("./injectCaller");
 
 const transform = promisify(babel.transform);
 
 module.exports = async function(source, options) {
   let result;
   try {
-    result = await transform(source, injectCaller(options));
+    result = await transform(source, options);
   } catch (err) {
     throw err.message && err.codeFrame ? new LoaderError(err) : err;
   }

--- a/src/transform.js
+++ b/src/transform.js
@@ -1,6 +1,7 @@
 const babel = require("@babel/core");
 const promisify = require("util.promisify");
 const LoaderError = require("./Error");
+const injectCaller = require("./injectCaller");
 
 const transform = promisify(babel.transform);
 
@@ -29,43 +30,3 @@ module.exports = async function(source, options) {
 };
 
 module.exports.version = babel.version;
-
-function injectCaller(opts) {
-  if (!supportsCallerOption()) return opts;
-
-  return Object.assign({}, opts, {
-    caller: Object.assign(
-      {
-        name: "babel-loader",
-
-        // Webpack >= 2 supports ESM and dynamic import.
-        supportsStaticESM: true,
-        supportsDynamicImport: true,
-      },
-      opts.caller,
-    ),
-  });
-}
-
-// TODO: We can remove this eventually, I'm just adding it so that people have
-// a little time to migrate to the newer RCs of @babel/core without getting
-// hard-to-diagnose errors about unknown 'caller' options.
-let supportsCallerOptionFlag = undefined;
-function supportsCallerOption() {
-  if (supportsCallerOptionFlag === undefined) {
-    try {
-      // Rather than try to match the Babel version, we just see if it throws
-      // when passed a 'caller' flag, and use that to decide if it is supported.
-      babel.loadPartialConfig({
-        caller: undefined,
-        babelrc: false,
-        configFile: false,
-      });
-      supportsCallerOptionFlag = true;
-    } catch (err) {
-      supportsCallerOptionFlag = false;
-    }
-  }
-
-  return supportsCallerOptionFlag;
-}


### PR DESCRIPTION
**Please Read the [CONTRIBUTING Guidelines](https://github.com/babel/babel-loader/blob/master/CONTRIBUTING.md)**
*In particular the portion on Commit Message Formatting*

**Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)

The caller option (added in https://github.com/babel/babel-loader/pull/660) is passed to the transform function here:

https://github.com/babel/babel-loader/blob/8f240b498bb24ef89f7b306f5ac806e84b813b0d/src/transform.js#L10-L10

But it is not passed to the loadPartialConfig function here:

https://github.com/babel/babel-loader/blob/8f240b498bb24ef89f7b306f5ac806e84b813b0d/src/index.js#L121-L121

This results in the caller option not being available in the project's `babel.config.js`

**What is the new behavior?**

The `caller` option is passed (subject to the existing compatibility check) in both cases.

**Does this PR introduce a breaking change?**
- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the following...

* Impact:
* Migration path for existing applications:
* Github Issue(s) this is regarding:


**Other information**:

I'm not sure why it works for `@babel/preset-env` - I assume the presets referenced from `babel.config.js` get access to the option from the `transform` call rather than the `loadPartialConfig` call.