### PR TITLE
Add `customize` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,8 @@ This loader also supports the following loader-specific option:
 
 * `cacheCompression`: Default `true`. When set, each Babel transform output will be compressed with Gzip. If you want to opt-out of cache compression, set it to `false` -- your project may benefit from this if it transpiles thousands of files.
 
+* `overrides`: Default `null`. See [Customized Loader](#customized-loader).
+
 **Note**: The `sourceMap` option is ignored. Instead, source maps are automatically enabled when webpack is configured to use them (via the [`devtool`](https://webpack.js.org/configuration/devtool/#devtool) config option).
 
 ## Troubleshooting
@@ -208,6 +210,9 @@ of Babel's configuration for each file that it processes.
 `babel` so that tooling can ensure that it using exactly the same `@babel/core`
 instance as the loader itself.
 
+This same callback can be provided under the `overrides` key in the loader options.
+You may also pass `overrides` a file name which exports this callback.
+
 ### Example
 
 ```js
@@ -230,7 +235,7 @@ module.exports = require("babel-loader").custom(babel => {
       };
     },
 
-    // Passed Babel's 'PartialConfig' object. 
+    // Passed Babel's 'PartialConfig' object.
     config(cfg) {
       if (cfg.hasFilesystemConfig()) {
         // Use the normal config

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ This loader also supports the following loader-specific option:
 
 * `cacheCompression`: Default `true`. When set, each Babel transform output will be compressed with Gzip. If you want to opt-out of cache compression, set it to `false` -- your project may benefit from this if it transpiles thousands of files.
 
-* `overrides`: Default `null`. See [Customized Loader](#customized-loader).
+* `customize`: Default `null`. See [Customized Loader](#customized-loader).
 
 **Note**: The `sourceMap` option is ignored. Instead, source maps are automatically enabled when webpack is configured to use them (via the [`devtool`](https://webpack.js.org/configuration/devtool/#devtool) config option).
 
@@ -210,8 +210,8 @@ of Babel's configuration for each file that it processes.
 `babel` so that tooling can ensure that it using exactly the same `@babel/core`
 instance as the loader itself.
 
-This same callback can be provided under the `overrides` key in the loader options.
-You may also pass `overrides` a file name which exports this callback.
+This same callback can be provided under the `customize` key in the loader options.
+You may also pass `customize` a file name which exports this callback.
 
 ### Example
 

--- a/src/index.js
+++ b/src/index.js
@@ -52,7 +52,7 @@ async function loader(source, inputSourceMap, overrides) {
 
   let loaderOptions = loaderUtils.getOptions(this) || {};
 
-  overrides = overrides || loaderOptions.overrides;
+  overrides = overrides || loaderOptions.customize;
   if (typeof overrides === "string") {
     overrides = require(overrides);
   }

--- a/src/index.js
+++ b/src/index.js
@@ -53,9 +53,12 @@ async function loader(source, inputSourceMap, overrides) {
   let loaderOptions = loaderUtils.getOptions(this) || {};
 
   overrides = overrides || loaderOptions.customize;
+  // customize may have been passed as a file, so we should load it
   if (typeof overrides === "string") {
     overrides = require(overrides);
   }
+  // customize may have been passed as a function and not an object (to access
+  // the `babel` variable), so let's build the overrides
   if (typeof overrides === "function") {
     overrides = overrides(babel);
   }

--- a/src/index.js
+++ b/src/index.js
@@ -113,7 +113,7 @@ async function loader(source, inputSourceMap, overrides) {
     sourceFileName: filename,
   });
   // Remove loader related options
-  delete programmaticOptions.overrides;
+  delete programmaticOptions.customize;
   delete programmaticOptions.cacheDirectory;
   delete programmaticOptions.cacheIdentifier;
   delete programmaticOptions.cacheCompression;

--- a/src/index.js
+++ b/src/index.js
@@ -52,6 +52,14 @@ async function loader(source, inputSourceMap, overrides) {
 
   let loaderOptions = loaderUtils.getOptions(this) || {};
 
+  overrides = overrides || loaderOptions.overrides;
+  if (typeof overrides === "string") {
+    overrides = require(overrides);
+  }
+  if (typeof overrides === "function") {
+    overrides = overrides(babel);
+  }
+
   let customOptions;
   if (overrides && overrides.customOptions) {
     const result = await overrides.customOptions.call(this, loaderOptions);
@@ -105,6 +113,7 @@ async function loader(source, inputSourceMap, overrides) {
     sourceFileName: filename,
   });
   // Remove loader related options
+  delete programmaticOptions.overrides;
   delete programmaticOptions.cacheDirectory;
   delete programmaticOptions.cacheIdentifier;
   delete programmaticOptions.cacheCompression;


### PR DESCRIPTION
Hey there!

We're looking to use [`babel-plugin-macros`](https://github.com/kentcdodds/babel-plugin-macros) without disabling caching.
Right now, there are larger talks about how to solve this (see https://github.com/babel/babel/issues/8497) via letting plugins hint to external file dependencies.

In the interim, we figured we'd disable caching *only* for files that include `.macro` or `/macro` in their source.
It would be nice to  [customize the loader](https://github.com/babel/babel-loader#customized-loader) through options instead of creating our own loader.

Thanks!