### PR TITLE
wip: include dynamic import automatically

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -121,7 +121,8 @@ async function loader(source, inputSourceMap, overrides) {
     delete loaderOptions.sourceMap;
   }
 
-  const programmaticOptions = Object.assign({}, loaderOptions, {
+  const defaultOptions = { parserOpts: { plugins: ["dynamicImport"] } };
+  const programmaticOptions = Object.assign({}, defaultOptions, loaderOptions, {
     filename,
     inputSourceMap: inputSourceMap || undefined,
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)

This fixes #515 . The dynamic import syntax plugin has to be manually added to webpack config even though webpack itself already supports dynamic imports.

**What is the new behavior?**

Dynamic import syntax is automatically supported.

**Does this PR introduce a breaking change?**
- [ ] Yes
- [x] No

**Other information**:

Please let me know if and where I should add docs/tests.