### PR TITLE
New [transformFileName] loader-specific option has been implemented.

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "@babel/cli": "^7.0.0",
     "@babel/core": "^7.0.0",
     "@babel/preset-env": "^7.0.0",
+    "@babel/preset-typescript": "^7.1.0",
     "ava": "0.25.0",
     "babel-eslint": "^8.0.0",
     "babel-plugin-istanbul": "^4.0.0",

--- a/src/index.js
+++ b/src/index.js
@@ -121,8 +121,18 @@ async function loader(source, inputSourceMap, overrides) {
     delete loaderOptions.sourceMap;
   }
 
+  let transformedFileName = filename;
+  if (loaderOptions.transformFileName) {
+    const pattern = loaderOptions.transformFileName.pattern;
+    const replace = loaderOptions.transformFileName.replace;
+
+    if (pattern && replace) {
+      transformedFileName = filename.replace(pattern, replace);
+    }
+  }
+
   const programmaticOptions = Object.assign({}, loaderOptions, {
-    filename,
+    filename: transformedFileName,
     inputSourceMap: inputSourceMap || undefined,
 
     // Set the default sourcemap behavior based on Webpack's mapping flag,
@@ -137,7 +147,9 @@ async function loader(source, inputSourceMap, overrides) {
     // modules.
     sourceFileName: filename,
   });
+
   // Remove loader related options
+  delete programmaticOptions.transformFileName;
   delete programmaticOptions.customize;
   delete programmaticOptions.cacheDirectory;
   delete programmaticOptions.cacheIdentifier;

--- a/test/fixtures/TestTS.ts
+++ b/test/fixtures/TestTS.ts
@@ -1,0 +1,12 @@
+export default class TestTsCls{
+  private name: string;
+
+  constructor(){
+    this.name = "SomeName";
+  }
+
+  someMethod(arg1: string): number{
+    return 42;
+  }
+  
+}

--- a/test/fixtures/TestTsVUE.vue
+++ b/test/fixtures/TestTsVUE.vue
@@ -1,0 +1,12 @@
+export default class TestTsVueCls{
+  private name123: string;
+
+  constructor(){
+    this.name123 = "SomeName123";
+  }
+
+  someMethod123(arg1: string): number{
+    return 42123;
+  }
+
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -344,6 +344,13 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.0.0"
 
+"@babel/plugin-syntax-typescript@^7.0.0":
+  version "7.1.5"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.1.5.tgz#956a1f43dec8a9d6b36221f5c865335555fdcb98"
+  integrity sha512-VqK5DFcS6/T8mT5CcJv1BwZLYFxkHiGZmP7Hs87F53lSToE/qfL7TpPrqFSaKyZi9w7Z/b/tmOGZZDupcJjFvw==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.0.0"
+
 "@babel/plugin-transform-arrow-functions@^7.0.0":
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-arrow-functions/-/plugin-transform-arrow-functions-7.0.0.tgz#a6c14875848c68a3b4b3163a486535ef25c7e749"
@@ -524,6 +531,14 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.0.0"
 
+"@babel/plugin-transform-typescript@^7.1.0":
+  version "7.1.0"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.1.0.tgz#81e7b4be90e7317cbd04bf1163ebf06b2adee60b"
+  integrity sha512-TOTtVeT+fekAesiCHnPz+PSkYSdOSLyLn42DI45nxg6iCdlQY6LIj/tYqpMB0y+YicoTUiYiXqF8rG6SKfhw6Q==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.0.0"
+    "@babel/plugin-syntax-typescript" "^7.0.0"
+
 "@babel/plugin-transform-unicode-regex@^7.0.0":
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-unicode-regex/-/plugin-transform-unicode-regex-7.0.0.tgz#c6780e5b1863a76fe792d90eded9fcd5b51d68fc"
@@ -577,6 +592,14 @@
     invariant "^2.2.2"
     js-levenshtein "^1.1.3"
     semver "^5.3.0"
+
+"@babel/preset-typescript@^7.1.0":
+  version "7.1.0"
+  resolved "https://registry.yarnpkg.com/@babel/preset-typescript/-/preset-typescript-7.1.0.tgz#49ad6e2084ff0bfb5f1f7fb3b5e76c434d442c7f"
+  integrity sha512-LYveByuF9AOM8WrsNne5+N79k1YxjNB6gmpCQsnuSBAcV8QUeB+ZUxQzL7Rz7HksPbahymKkq2qBR+o36ggFZA==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.0.0"
+    "@babel/plugin-transform-typescript" "^7.1.0"
 
 "@babel/template@7.0.0-beta.40":
   version "7.0.0-beta.40"


### PR DESCRIPTION
    REASON

A reason of implementing this feature is [VueJS TypeScript SFC]
compilation trouble with the usage of [babel, babel-loader].
Issue environment:  webpback@4.25.x,  vue@2.5.x., babel@7.1.x,
babel-loader@8.0.x)

Ordinal *.ts files are compiled OK
but SFC - the [babel-loader] doesn’t understand that
[vue-loader] gives it TypeScript-code.

I know, that similar problem solved for the [ts-loader] by its option
[appendTsSuffixTo], but I haven't found any similar settings for
[babel-loader].

    DESCRIPTION

babel-loader have two file names field in a loader's options object:
 - filename
 - sourceFilename

If I've found out correctly, the last one is strongly bound
to a physical resource (a file) and the first one is a logical name
in some sense.
Consequently, I change the fist file name options.
Well, in my test build that solution works without any negative impact.

I think that the [ts-loader] solves such problem by similar solution.

    OPTION'S STRUCTURE

transformFileName:{
    pattern: RegEx,
    replace: 'string_of_content_instead_of_regex'
}

