### PR TITLE
Minor change in docs to reflect new way of setting cacheDirectory.

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ module: {
 
 This loader also supports the following loader-specific option:
 
-* `cacheDirectory`: Default `false`. When set, the given directory will be used to cache the results of the loader. Future webpack builds will attempt to read from the cache to avoid needing to run the potentially expensive Babel recompilation process on each run. If the value is blank (`loader: 'babel-loader?cacheDirectory'`) or `true` (`loader: 'babel-loader?cacheDirectory=true'`), the loader will use the default cache directory in `node_modules/.cache/babel-loader` or fallback to the default OS temporary file directory if no `node_modules` folder could be found in any root directory.
+* `cacheDirectory`: Default `false`. When set, the given directory will be used to cache the results of the loader. Future webpack builds will attempt to read from the cache to avoid needing to run the potentially expensive Babel recompilation process on each run. If the value is set to `true` in options (`{cacheDirectory: true}`), the loader will use the default cache directory in `node_modules/.cache/babel-loader` or fallback to the default OS temporary file directory if no `node_modules` folder could be found in any root directory.
 
 * `cacheIdentifier`: Default is a string composed by the `@babel/core`'s version, the `babel-loader`'s version, the contents of `.babelrc` file if it exists, and the value of the environment variable `BABEL_ENV` with a fallback to the `NODE_ENV` environment variable. This can be set to a custom value to force cache busting if the identifier changes.
 


### PR DESCRIPTION
**Please Read the [CONTRIBUTING Guidelines](https://github.com/babel/babel-loader/blob/master/CONTRIBUTING.md)**
*In particular the portion on Commit Message Formatting*

**Please check if the PR fulfills these requirements**
- [x] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

- [x] Other... Please describe: Minor documentation change.

Specifying cacheDirectory like this: `babel-loader?cacheDirectory` doesn't seem to work anymore in the newest version in favor of the options object. Updated the docs to reflect this.


