### PR TITLE
Add supportsTopLevelAwait to caller

### DIFF
--- a/src/injectCaller.js
+++ b/src/injectCaller.js
@@ -13,7 +13,7 @@ module.exports = function injectCaller(opts) {
         supportsDynamicImport: true,
 
         // Webpack 5 supports TLA behind a flag. We enable it by default
-        // for Babel, and then webpack will throw an error is the experimental
+        // for Babel, and then webpack will throw an error if the experimental
         // flag isn't enabled.
         supportsTopLevelAwait: true,
       },

--- a/src/injectCaller.js
+++ b/src/injectCaller.js
@@ -11,6 +11,11 @@ module.exports = function injectCaller(opts) {
         // Webpack >= 2 supports ESM and dynamic import.
         supportsStaticESM: true,
         supportsDynamicImport: true,
+
+        // Webpack 5 supports TLA behind a flag. We enable it by default
+        // for Babel, and then webpack will throw an error is the experimental
+        // flag isn't enabled.
+        supportsTopLevelAwait: true,
       },
       opts.caller,
     ),


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the new behavior?**

Babel 7.7.0 will have support for parsing top-level await expressions. Since webpack 5 has experimental support for top-level await, it can be enabled by default in Babel.
If the `experimental.topLevelAwait` flag isn't enabled in webpack, Babel will parse it and then webpack will generate an error suggesting to enable that option.


**Does this PR introduce a breaking change?**
- [ ] Yes
- [x] No

**Other information**:

I didn't add a test because
1) Babel 7.7 isn't released yet
2) I couldn't get TLA to work in webpack, even without using Babel.
