### PR TITLE
fix: use async config loading if available

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest]
-        node-version: [10.x, 12.x, 13.x, 14.x, 15.x]
+        node-version: [10.x, 12.x, 14.x, 15.x]
         webpack-version: [latest, next]
         include:
           - node: 14.x

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest]
-        node-version: [10.x, 12.x, 14.x]
+        node-version: [10.x, 12.x, 13.x, 14.x, 15.x]
         webpack-version: [latest, next]
         include:
           - node: 14.x

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "files": [
     "lib"
   ],
+  "type": "commonjs",
   "main": "lib/index.js",
   "engines": {
     "node": ">= 6.9"
@@ -42,6 +43,7 @@
     "react-intl": "^3.3.2",
     "react-intl-webpack-plugin": "^0.3.0",
     "rimraf": "^3.0.0",
+    "semver": "7.0.0",
     "webpack": "^4.0.0"
   },
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,6 @@
   "files": [
     "lib"
   ],
-  "type": "commonjs",
   "main": "lib/index.js",
   "engines": {
     "node": ">= 6.9"

--- a/src/index.js
+++ b/src/index.js
@@ -159,7 +159,9 @@ async function loader(source, inputSourceMap, overrides) {
     );
   }
 
-  const config = babel.loadPartialConfig(
+  // babel.loadPartialConfigAsync is available in v7.8.0+
+  const { loadPartialConfigAsync = babel.loadPartialConfig } = babel;
+  const config = await loadPartialConfigAsync(
     injectCaller(programmaticOptions, this.target),
   );
   if (config) {

--- a/test/fixtures/babelrc.mjs
+++ b/test/fixtures/babelrc.mjs
@@ -1,0 +1,3 @@
+export default {
+  presets: ["@babel/preset-env"]
+};

--- a/test/loader.test.js
+++ b/test/loader.test.js
@@ -2,6 +2,7 @@ import test from "ava";
 import fs from "fs";
 import path from "path";
 import rimraf from "rimraf";
+import { gte } from "semver";
 import webpack from "webpack";
 import createTestDirectory from "./helpers/createTestDirectory";
 
@@ -127,3 +128,56 @@ test.cb(
     });
   },
 );
+
+test.cb("should load ESM config files", t => {
+  const config = Object.assign({}, globalConfig, {
+    entry: path.join(__dirname, "fixtures/constant.js"),
+    output: {
+      path: t.context.directory,
+    },
+    module: {
+      rules: [
+        {
+          test: /\.js$/,
+          loader: babelLoader,
+          exclude: /node_modules/,
+          options: {
+            // Use relative path starting with a dot to satisfy module loader.
+            // https://github.com/nodejs/node/issues/31710
+            // File urls doesn't work with current resolve@1.12.0 package.
+            extends: (
+              "." +
+              path.sep +
+              path.relative(
+                process.cwd(),
+                path.resolve(__dirname, "fixtures/babelrc.mjs"),
+              )
+            ).replace(/\\/g, "/"),
+            babelrc: false,
+          },
+        },
+      ],
+    },
+  });
+
+  webpack(config, (err, stats) => {
+    t.is(err, null);
+    // Node supports ESM without a flag starting from 13.2.0.
+    if (gte(process.version, `13.2.0`)) {
+      t.deepEqual(
+        stats.compilation.errors.map(e => e.message),
+        [],
+      );
+    } else {
+      t.is(stats.compilation.errors.length, 1);
+      const moduleBuildError = stats.compilation.errors[0];
+      const babelLoaderError = moduleBuildError.error;
+      t.true(babelLoaderError instanceof Error);
+      // Error messages are slightly different between versions:
+      // "modules aren't supported" or "modules not supported".
+      t.regex(babelLoaderError.message, /supported/i);
+    }
+    t.is(stats.compilation.warnings.length, 0);
+    t.end();
+  });
+});

--- a/test/loader.test.js
+++ b/test/loader.test.js
@@ -2,7 +2,7 @@ import test from "ava";
 import fs from "fs";
 import path from "path";
 import rimraf from "rimraf";
-import { gte } from "semver";
+import { satisfies } from "semver";
 import webpack from "webpack";
 import createTestDirectory from "./helpers/createTestDirectory";
 
@@ -162,8 +162,8 @@ test.cb("should load ESM config files", t => {
 
   webpack(config, (err, stats) => {
     t.is(err, null);
-    // Node supports ESM without a flag starting from 13.2.0.
-    if (gte(process.version, `13.2.0`)) {
+    // Node supports ESM without a flag starting from 12.13.0 and 13.2.0.
+    if (satisfies(process.version, `^12.13.0 || >=13.2.0`)) {
       t.deepEqual(
         stats.compilation.errors.map(e => e.message),
         [],

--- a/test/sourcemaps.test.js
+++ b/test/sourcemaps.test.js
@@ -171,11 +171,13 @@ test.cb("should output webpack's devtoolModuleFilename option", t => {
           t.is(err, null);
 
           // The full absolute path is included in the sourcemap properly
-          t.not(
-            data
-              .toString()
-              .indexOf(JSON.stringify(`==${globalConfig.entry}==`)),
-            -1,
+          t.regex(
+            data.toString(),
+            new RegExp(
+              // Forward slashes on Windows are common in Babel/Webpack:
+              // https://github.com/webpack/webpack/pull/1909
+              JSON.stringify(`==${globalConfig.entry.replace(/\\/g, "/")}==`),
+            ),
           );
 
           t.end();

--- a/test/sourcemaps.test.js
+++ b/test/sourcemaps.test.js
@@ -171,13 +171,11 @@ test.cb("should output webpack's devtoolModuleFilename option", t => {
           t.is(err, null);
 
           // The full absolute path is included in the sourcemap properly
-          t.regex(
-            data.toString(),
-            new RegExp(
-              // Forward slashes on Windows are common in Babel/Webpack:
-              // https://github.com/webpack/webpack/pull/1909
-              JSON.stringify(`==${globalConfig.entry.replace(/\\/g, "/")}==`),
-            ),
+          t.not(
+            data
+              .toString()
+              .indexOf(JSON.stringify(`==${globalConfig.entry}==`)),
+            -1,
           );
 
           t.end();


### PR DESCRIPTION
**Please Read the [CONTRIBUTING Guidelines](https://github.com/babel/babel-loader/blob/master/CONTRIBUTING.md)**
*In particular the portion on Commit Message Formatting*

**Please check if the PR fulfills these requirements**
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)

Fixes #824 

**What is the new behavior?**

If `@babel/core` is `>=7.8.0`, then ESM config will be found and loaded asynchronously.

**Does this PR introduce a breaking change?**
- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the following...

* Impact:
* Migration path for existing applications:
* Github Issue(s) this is regarding:


**Other information**:
