### PR TITLE
feat: expose webpack target via babel caller

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,9 +193,9 @@ In the case one of your dependencies is installing `babel` and you cannot uninst
   }
 ```
 
-## Customize config for specific Webpack target
+## Customize config based on webpack target
 
-Webpack supports bundling for multiple different [targets](https://webpack.js.org/concepts/targets/) including the web, and node. Sometimes it can be useful to have a slightly different babel configuration for the different environments. This loader provides a `target` property via the babel [caller](https://babeljs.io/docs/en/config-files#apicallercb) API which can be used in this case.
+Webpack supports bundling multiple [targets](https://webpack.js.org/concepts/targets/). For cases where you may want different Babel configurations for each target (like `web` _and_ `node`), this loader provides a `target` property via Babel's [caller](https://babeljs.io/docs/en/config-files#apicallercb) API.
 
 For example, to change the environment targets passed to `@babel/preset-env` based on the webpack target:
 

--- a/README.md
+++ b/README.md
@@ -193,6 +193,37 @@ In the case one of your dependencies is installing `babel` and you cannot uninst
   }
 ```
 
+## Customize config for specific Webpack target
+
+Webpack supports bundling for multiple different [targets](https://webpack.js.org/concepts/targets/) including the web, and node. Sometimes it can be useful to have a slightly different babel configuration for the different environments. This loader provides a `target` property via the babel [caller](https://babeljs.io/docs/en/config-files#apicallercb) API which can be used in this case.
+
+For example, to change the environment targets passed to `@babel/preset-env` based on the webpack target:
+
+```javascript
+// babel.config.js
+
+module.exports = api => {
+  return {
+    plugins: [
+      "@babel/plugin-proposal-nullish-coalescing-operator",
+      "@babel/plugin-proposal-optional-chaining"
+    ],
+    presets: [
+      [
+        "@babel/preset-env",
+        {
+          useBuiltIns: "entry",
+          // caller.target will be the same as the target option from webpack
+          targets: api.caller(caller => caller && caller.target === "node")
+            ? { node: "current" }
+            : { chrome: "58", ie: "11" }
+        }
+      ]
+    ]
+  }
+}
+```
+
 ## Customized Loader
 
 `babel-loader` exposes a loader-builder utility that allows users to add custom handling

--- a/src/index.js
+++ b/src/index.js
@@ -158,7 +158,9 @@ async function loader(source, inputSourceMap, overrides) {
     );
   }
 
-  const config = babel.loadPartialConfig(injectCaller(programmaticOptions));
+  const config = babel.loadPartialConfig(
+    injectCaller(programmaticOptions, this.target),
+  );
   if (config) {
     let options = config.options;
     if (overrides && overrides.config) {

--- a/src/injectCaller.js
+++ b/src/injectCaller.js
@@ -1,12 +1,16 @@
 const babel = require("@babel/core");
 
-module.exports = function injectCaller(opts) {
+module.exports = function injectCaller(opts, target) {
   if (!supportsCallerOption()) return opts;
 
   return Object.assign({}, opts, {
     caller: Object.assign(
       {
         name: "babel-loader",
+
+        // Provide plugins with insight into webpack target.
+        // https://github.com/babel/babel-loader/issues/787
+        target,
 
         // Webpack >= 2 supports ESM and dynamic import.
         supportsStaticESM: true,


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)
Currently it is not possible to determine inside of a `babel.config.js` file what the webpack target being bundled for is.


**What is the new behavior?**
Exposes the current webpack target using the babel [caller](https://babeljs.io/docs/en/config-files#apicallercb) api.


**Does this PR introduce a breaking change?**
- [ ] Yes
- [x] No

**Other information**:
I'm happy to add a test if necessary. However there are not existing tests for the already injected caller data. I think it'd require a bit of effort to setup correctly since we'd probably want to write a fake plugin which just checked what the caller was.

Implements #787 