### PR TITLE
chore: replace mkdirp by make-dir@2

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "find-cache-dir": "^2.1.0",
     "loader-utils": "^1.4.0",
-    "mkdirp": "^0.5.3",
+    "make-dir": "^2.1.0",
     "pify": "^4.0.1",
     "schema-utils": "^2.6.5"
   },

--- a/src/cache.js
+++ b/src/cache.js
@@ -12,7 +12,6 @@ const os = require("os");
 const path = require("path");
 const zlib = require("zlib");
 const crypto = require("crypto");
-const mkdirpOrig = require("mkdirp");
 const findCacheDir = require("find-cache-dir");
 const promisify = require("pify");
 
@@ -24,7 +23,7 @@ const readFile = promisify(fs.readFile);
 const writeFile = promisify(fs.writeFile);
 const gunzip = promisify(zlib.gunzip);
 const gzip = promisify(zlib.gzip);
-const mkdirp = promisify(mkdirpOrig);
+const makeDir = require("make-dir");
 
 /**
  * Read the contents from the compressed file.
@@ -99,7 +98,7 @@ const handleCache = async function(directory, params) {
 
   // Make sure the directory exists.
   try {
-    await mkdirp(directory);
+    await makeDir(directory);
   } catch (err) {
     if (fallback) {
       return handleCache(os.tmpdir(), params);

--- a/yarn.lock
+++ b/yarn.lock
@@ -4451,7 +4451,7 @@ mixin-deep@^1.2.0:
     for-in "^1.0.2"
     is-extendable "^1.0.1"
 
-mkdirp@^0.5.0, mkdirp@^0.5.1, mkdirp@^0.5.3:
+mkdirp@^0.5.0, mkdirp@^0.5.1:
   version "0.5.3"
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.3.tgz#5a514b7179259287952881e94410ec5465659f8c"
   integrity sha512-P+2gwrFqx8lhew375MQHHeTlY8AuOJSrGf0R5ddkEndUkmwpgUob/vQuBD1V22/Cw1/lJr4x+EjllSezBThzBg==


### PR DESCRIPTION
**Please Read the [CONTRIBUTING Guidelines](https://github.com/babel/babel-loader/blob/master/CONTRIBUTING.md)**
*In particular the portion on Commit Message Formatting*

**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
- [x] Refactoring (no functional changes, no api changes)

**What is the current behavior?** (You can also link to an open issue here)
Behavior is unchanged.

**What is the new behavior?**
Replace `mkdirp` by `make-dir@2` so that
1) we still support node>=6
2) `babel-loader` does not depend on `minimist` anymore. (`mkdirp` bundled a cli but we are not using it anyway)
3) installing `babel-loader` should not print a frustrating deprecated message from `mkdirp`


**Does this PR introduce a breaking change?**
- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the following...

* Impact:
* Migration path for existing applications:
* Github Issue(s) this is regarding: 
Fixes #833 