### PR TITLE
Webpack is not a peerDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,8 +17,7 @@
     "schema-utils": "^2.6.5"
   },
   "peerDependencies": {
-    "@babel/core": "^7.0.0",
-    "webpack": ">=2"
+    "@babel/core": "^7.0.0"
   },
   "devDependencies": {
     "@babel/cli": "^7.2.0",


### PR DESCRIPTION
Webpack is not used in sources and babel-loader does not directly depend on it.