### PR TITLE
docs: add loadPartialConfig info in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,8 @@ module: {
 }
 ```
 
+*Please note that this loader internally uses `babel.loadPartialConfig`, which means that it will by default use the configuration from your project specific babel config file and any options you specify here would override those set in the project specific babel config.*
+
 This loader also supports the following loader-specific option:
 
 * `cacheDirectory`: Default `false`. When set, the given directory will be used to cache the results of the loader. Future webpack builds will attempt to read from the cache to avoid needing to run the potentially expensive Babel recompilation process on each run. If the value is set to `true` in options (`{cacheDirectory: true}`), the loader will use the default cache directory in `node_modules/.cache/babel-loader` or fallback to the default OS temporary file directory if no `node_modules` folder could be found in any root directory.


### PR DESCRIPTION
To make it more clear that the options specified here override the existing babel config/

**Please Read the [CONTRIBUTING Guidelines](https://github.com/babel/babel-loader/blob/master/CONTRIBUTING.md)**
*In particular the portion on Commit Message Formatting*

**Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Other... Please describe:
changes to README

**What is the current behavior?** (You can also link to an open issue here)
N/A


**What is the new behavior?**
remains the same


**Does this PR introduce a breaking change?**
- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the following...

* Impact:
* Migration path for existing applications:
* Github Issue(s) this is regarding:


**Other information**:
related to https://github.com/babel/babel-loader/issues/823