### PR TITLE
Add docs for using babel with Webpack

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,7 +191,7 @@ In the case one of your dependencies is installing `babel` and you cannot uninst
   }
 ```
 
-### Compiled JavaScript won't run and throw errors
+### Exclude libraries that should not be transpiled
 
 `core-js` and `webpack/buildin` will cause errors if they are transplied by Babel.
 

--- a/README.md
+++ b/README.md
@@ -193,7 +193,7 @@ In the case one of your dependencies is installing `babel` and you cannot uninst
 
 ### Exclude libraries that should not be transpiled
 
-`core-js` and `webpack/buildin` will cause errors if they are transplied by Babel.
+`core-js` and `webpack/buildin` will cause errors if they are transpiled by Babel.
 
 You will need to exclude them form `babel-loader`.
 

--- a/README.md
+++ b/README.md
@@ -191,6 +191,28 @@ In the case one of your dependencies is installing `babel` and you cannot uninst
   }
 ```
 
+### Compiled JavaScript won't run and throw errors
+
+`core-js` and `webpack/buildin` will cause errors if they are transplied by Babel.
+
+You will need to exclude them form `babel-loader`.
+
+```js
+{
+  "loader": "babel-loader",
+  "options": {
+    "exclude": [
+      // \\ for Windows, \/ for Mac OS and Linux
+      /node_modules[\\\/]core-js/,
+      /node_modules[\\\/]webpack[\\\/]buildin/,
+    ],
+    "presets": [
+      "@babel/preset-env"
+    ]
+  }
+}
+```
+
 ## Customize config based on webpack target
 
 Webpack supports bundling multiple [targets](https://webpack.js.org/concepts/targets/). For cases where you may want different Babel configurations for each target (like `web` _and_ `node`), this loader provides a `target` property via Babel's [caller](https://babeljs.io/docs/en/config-files#apicallercb) API.


### PR DESCRIPTION
Related: https://github.com/babel/babel/issues/12068, https://github.com/zloirock/core-js/issues/743#issuecomment-572074215, https://stackoverflow.com/a/59647913/11077662

This paragraph was originally introduced in https://github.com/babel/website/pull/2337, but later I was suggested by @existentialism to put this documentation to `babel-loader` instead of `@babel/preset-env`.

**Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Other... Please describe: docs update