### PR TITLE
Move @ava/babel to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,6 @@
     "node": ">= 6.9"
   },
   "dependencies": {
-    "@ava/babel": "^1.0.1",
     "find-cache-dir": "^2.1.0",
     "loader-utils": "^1.4.0",
     "make-dir": "^2.1.0",
@@ -22,6 +21,7 @@
     "webpack": ">=2"
   },
   "devDependencies": {
+    "@ava/babel": "^1.0.1",
     "@babel/cli": "^7.12.1",
     "@babel/core": "^7.12.3",
     "@babel/preset-env": "^7.12.1",


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Other: dependencies fix.

**What is the current behavior?** (You can also link to an open issue here)

When installing babel-loader, `@ava/babel` is installed with it while it's not used

**What is the new behavior?**

It's not installed anymore.

**Does this PR introduce a breaking change?**
- [ ] Yes
- [x] No

**Other information**:

Adding it to `dependencies` instead of `devDependencies` was probably a mistake, this fixes it.
