### PR TITLE
Upgrade dependencies & replace pify

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,9 +10,9 @@
     "node": ">= 8.9"
   },
   "dependencies": {
-    "find-cache-dir": "^2.1.0",
+    "find-cache-dir": "^3.3.1",
     "loader-utils": "^1.4.0",
-    "make-dir": "^2.1.0",
+    "make-dir": "^3.1.0",
     "pify": "^4.0.1",
     "schema-utils": "^2.6.5"
   },

--- a/package.json
+++ b/package.json
@@ -13,7 +13,6 @@
     "find-cache-dir": "^3.3.1",
     "loader-utils": "^1.4.0",
     "make-dir": "^3.1.0",
-    "pify": "^4.0.1",
     "schema-utils": "^2.6.5"
   },
   "peerDependencies": {

--- a/src/cache.js
+++ b/src/cache.js
@@ -13,7 +13,7 @@ const path = require("path");
 const zlib = require("zlib");
 const crypto = require("crypto");
 const findCacheDir = require("find-cache-dir");
-const promisify = require("pify");
+const { promisify } = require("util");
 
 const transform = require("./transform");
 // Lazily instantiated when needed

--- a/src/transform.js
+++ b/src/transform.js
@@ -1,5 +1,5 @@
 const babel = require("@babel/core");
-const promisify = require("pify");
+const { promisify } = require("util");
 const LoaderError = require("./Error");
 
 const transform = promisify(babel.transform);

--- a/yarn.lock
+++ b/yarn.lock
@@ -2176,7 +2176,6 @@ __metadata:
     loader-utils: ^1.4.0
     make-dir: ^3.1.0
     nyc: ^15.1.0
-    pify: ^4.0.1
     pnp-webpack-plugin: ^1.6.4
     prettier: ^2.1.2
     react: ^17.0.1

--- a/yarn.lock
+++ b/yarn.lock
@@ -2170,11 +2170,11 @@ __metadata:
     eslint-config-prettier: ^6.3.0
     eslint-plugin-flowtype: ^5.2.0
     eslint-plugin-prettier: ^3.0.0
-    find-cache-dir: ^2.1.0
+    find-cache-dir: ^3.3.1
     husky: ^4.3.0
     lint-staged: ^10.5.1
     loader-utils: ^1.4.0
-    make-dir: ^2.1.0
+    make-dir: ^3.1.0
     nyc: ^15.1.0
     pify: ^4.0.1
     pnp-webpack-plugin: ^1.6.4
@@ -3811,18 +3811,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"find-cache-dir@npm:^2.1.0":
-  version: 2.1.0
-  resolution: "find-cache-dir@npm:2.1.0"
-  dependencies:
-    commondir: ^1.0.1
-    make-dir: ^2.0.0
-    pkg-dir: ^3.0.0
-  checksum: 6e996026565b651d709964abad7f353976e83e869dffae96f73f99f51078eb856a82411a3f2c77f89040c4976aed28248a761590f7237796a8578d00c6b34446
-  languageName: node
-  linkType: hard
-
-"find-cache-dir@npm:^3.2.0":
+"find-cache-dir@npm:^3.2.0, find-cache-dir@npm:^3.3.1":
   version: 3.3.1
   resolution: "find-cache-dir@npm:3.3.1"
   dependencies:
@@ -5380,7 +5369,7 @@ fsevents@~2.1.2:
   languageName: node
   linkType: hard
 
-"make-dir@npm:^2.0.0, make-dir@npm:^2.1.0":
+"make-dir@npm:^2.1.0":
   version: 2.1.0
   resolution: "make-dir@npm:2.1.0"
   dependencies:
@@ -5390,7 +5379,7 @@ fsevents@~2.1.2:
   languageName: node
   linkType: hard
 
-"make-dir@npm:^3.0.0, make-dir@npm:^3.0.2":
+"make-dir@npm:^3.0.0, make-dir@npm:^3.0.2, make-dir@npm:^3.1.0":
   version: 3.1.0
   resolution: "make-dir@npm:3.1.0"
   dependencies:
@@ -6207,15 +6196,6 @@ fsevents@~2.1.2:
     find-up: ^3.0.0
     load-json-file: ^5.2.0
   checksum: e0567c5b0f7d7abe3d9f87650436ee8f7175b6ed55027e72fc186fed124b05b2563233a5ad4d2f0468730439687c8e75128fa220b4ba0d05e186149b8788337e
-  languageName: node
-  linkType: hard
-
-"pkg-dir@npm:^3.0.0":
-  version: 3.0.0
-  resolution: "pkg-dir@npm:3.0.0"
-  dependencies:
-    find-up: ^3.0.0
-  checksum: f29a7d0134ded2c5fb71eb9439809a415d4b79bd4648581486361a83e0dcca392739603de268410c154f44c60449f3e0855bda65bfb3256f0726a88e91699d8f
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
**Please Read the [CONTRIBUTING Guidelines](https://github.com/babel/babel-loader/blob/main/CONTRIBUTING.md)**
*In particular the portion on Commit Message Formatting*

**Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [X] Other... Please describe: Dependency upgrades

**What is the current behavior?** (You can also link to an open issue here)

`babel-loader` is loading older dependencies than necessary 

**What is the new behavior?**

`babel-loader` is loading the newest possible dependency 

**Does this PR introduce a breaking change?**
- [ ] Yes
- [X] No

If this PR contains a breaking change, please describe the following...

* Impact:
* Migration path for existing applications:
* Github Issue(s) this is regarding:

**Other information**:

Since #882 raised the minimum Node version to 8.9 some dependency updates & replacements are now possible.

Note I didn't update `loader-utils` to version 2 since not even Webpack@5 is using it. I'm not sure what's going on with that package. Also `schema-utils` version3 requires Node.js 10.13 and thus can't be upgraded.