### PR TITLE
fix: add all babel config files to file dependency

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -209,10 +209,19 @@ async function loader(source, inputSourceMap, overrides) {
       result = await transform(source, options);
     }
 
-    // TODO: Babel should really provide the full list of config files that
-    // were used so that this can also handle files loaded with 'extends'.
-    if (typeof config.babelrc === "string") {
-      this.addDependency(config.babelrc);
+    // Availabe since Babel 7.12
+    // https://github.com/babel/babel/pull/11907
+    if (config.files) {
+      config.files.forEach(configFile => this.addDependency(configFile));
+    } else {
+      // .babelrc.json
+      if (typeof config.babelrc === "string") {
+        this.addDependency(config.babelrc);
+      }
+      // babel.config.js
+      if (config.config) {
+        this.addDependency(config.config);
+      }
     }
 
     if (result) {


### PR DESCRIPTION
**Please Read the [CONTRIBUTING Guidelines](https://github.com/babel/babel-loader/blob/main/CONTRIBUTING.md)**
*In particular the portion on Commit Message Formatting*

**Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)
In a webpack dev server, when `babel.config.js` is editted, files are not recompiled.


**What is the new behavior?**
They are now recompiled.


**Does this PR introduce a breaking change?**
- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the following...

* Impact:
* Migration path for existing applications:
* Github Issue(s) this is regarding:


**Other information**:
A follow-up to https://github.com/babel/babel/pull/11907

Fixes #898 