### PR TITLE
Ensure babel understands webpack sourcemaps

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -52,7 +52,17 @@ function makeLoader(callback) {
   };
 }
 
-async function loader(source, inputSourceMap, overrides) {
+function parseSourceMap(sourcemap) {
+  try {
+    return typeof sourcemap === "string" ? JSON.parse(sourcemap) : sourcemap;
+  } catch (_e) {
+    return sourcemap;
+  }
+}
+
+async function loader(source, sourceMap, overrides) {
+  const inputSourceMap = parseSourceMap(sourceMap);
+
   const filename = this.resourcePath;
 
   let loaderOptions = loaderUtils.getOptions(this) || {};


### PR DESCRIPTION
**Please Read the [CONTRIBUTING Guidelines](https://github.com/babel/babel-loader/blob/main/CONTRIBUTING.md)**
*In particular the portion on Commit Message Formatting*

**Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)
Sourcemaps from other loaders coming as strings fail to be processed by `babel-loader` even when though they comfort to webpack's standars:

https://webpack.js.org/api/loaders/#thiscallback
https://github.com/mozilla/source-map#new-sourcemapconsumerrawsourcemap

**What is the new behavior?**
Babel loader processes these sourcemaps before passing them down to babel so they work correctly.

**Does this PR introduce a breaking change?**
- [ ] Yes
- [x] No

**Other information**:
