### PR TITLE
fix: respect `inputSourceMap` loader option

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -130,7 +130,7 @@ async function loader(source, inputSourceMap, overrides) {
 
   const programmaticOptions = Object.assign({}, loaderOptions, {
     filename,
-    inputSourceMap: inputSourceMap || undefined,
+    inputSourceMap: inputSourceMap || loaderOptions.inputSourceMap,
 
     // Set the default sourcemap behavior based on Webpack's mapping flag,
     // but allow users to override if they want.


### PR DESCRIPTION

**Please Read the [CONTRIBUTING Guidelines](https://github.com/babel/babel-loader/blob/main/CONTRIBUTING.md)**
*In particular the portion on Commit Message Formatting*

**Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)
Currently, when the loader is invoked without a `map` object the `inputSourceMap` fallbacks to `undefined`.

This caused the sourcemap to be loaded by Babel since this defaults to `true` https://babeljs.io/docs/en/options#inputsourcemap

Thus, currently there is no way to disable `inputSourceMap` when using this loader.


**What is the new behavior?**
Respect `inputSourceMap` option provided by the loader options.


**Does this PR introduce a breaking change?**
- [ ] Yes
- [X] No

If this PR contains a breaking change, please describe the following...

* Impact:
* Migration path for existing applications:
* Github Issue(s) this is regarding:


**Other information**:
