### PR TITLE
Add more exhaustive example on customized-loader

### DIFF
--- a/README.md
+++ b/README.md
@@ -319,7 +319,8 @@ your `custom` callback function.
 ```js
 // Export from "./my-custom-loader.js" or whatever you want.
 module.exports = require("babel-loader").custom(babel => {
-  function myPlugin() {
+  // Extract the custom options in the custom plugin
+  function myPlugin({ opt1, opt2 }) {
     return {
       visitor: {},
     };
@@ -338,7 +339,7 @@ module.exports = require("babel-loader").custom(babel => {
     },
 
     // Passed Babel's 'PartialConfig' object.
-    config(cfg) {
+    config(cfg, { customOptions }) {
       if (cfg.hasFilesystemConfig()) {
         // Use the normal config
         return cfg.options;
@@ -349,8 +350,8 @@ module.exports = require("babel-loader").custom(babel => {
         plugins: [
           ...(cfg.options.plugins || []),
 
-          // Include a custom plugin in the options.
-          myPlugin,
+          // Include a custom plugin in the options and passing it the customOptions object.
+          (...pluginArgs) => myPlugin(customOptions, ...pluginArgs),
         ],
       };
     },
@@ -385,7 +386,7 @@ Given the loader's options, split custom options out of `babel-loader`'s
 options.
 
 
-### `config(cfg: PartialConfig): Object`
+### `config(cfg: PartialConfig, options: { source, customOptions }): Object`
 
 Given Babel's `PartialConfig` object, return the `options` object that should
 be passed to `babel.transform`.


### PR DESCRIPTION
**Please Read the [CONTRIBUTING Guidelines](https://github.com/babel/babel-loader/blob/main/CONTRIBUTING.md)**
*In particular the portion on Commit Message Formatting*

**Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)

In the documentation for babel-loader, we can find an entry for a customized loader. In this documentation the example given provides clues to `customOptions` in the loader, but doesn't actually use it to pass those options to a custom plugin provided to the `config` function.

The custom options are described:
![image](https://user-images.githubusercontent.com/5495320/111665355-96717300-880a-11eb-9df0-2afba5e168bd.png)

And then the plugin doesn't use anything.
![image](https://user-images.githubusercontent.com/5495320/111665516-b99c2280-880a-11eb-9928-0d87d0b69427.png)

On top of this, the parameters that are passed to the plugin don't contain the `customOptions` defined.


**What is the new behavior?**

Update the documentation to provide a more exhaustive example on how to pass the `customOptions` to the custom plugin provided to the `config` function.

Based on the pull request that actually implemented this #619.


**Does this PR introduce a breaking change?**
- [ ] Yes
- [x] No
