### PR TITLE
doc(README.md): fix a broken markdown link

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,7 +252,7 @@ You will need to exclude them form `babel-loader`.
 
 ### Top level function (IIFE) is still arrow (on Webpack 5)
 
-That function is injected by Webpack itself _after_ running `babel-loader`. By default Webpack asumes that your target environment supports some ES2015 features, but you can overwrite this behavior using the `output.environment` Webpack option ([documentation]((https://webpack.js.org/configuration/output/#outputenvironment)).
+That function is injected by Webpack itself _after_ running `babel-loader`. By default Webpack asumes that your target environment supports some ES2015 features, but you can overwrite this behavior using the `output.environment` Webpack option ([documentation](https://webpack.js.org/configuration/output/#outputenvironment)).
 
 To avoid the top-level arrow function, you can use `output.environment.arrowFunction`:
 


### PR DESCRIPTION
**Please Read the [CONTRIBUTING Guidelines](https://github.com/babel/babel-loader/blob/main/CONTRIBUTING.md)**
*In particular the portion on Commit Message Formatting*

**Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [✅ ] Other... Please describe: docs update

**What is the current behavior?** (You can also link to an open issue here)
due to an extra '(', the link to webpack documentatio is broken
![image](https://user-images.githubusercontent.com/18344013/138243251-b838fdf9-7be6-49d1-80a8-d674f9d57673.png)



**What is the new behavior?**
link is working now



**Does this PR introduce a breaking change?**
- [ ] Yes
- [✅ ] No

If this PR contains a breaking change, please describe the following...

* Impact:
* Migration path for existing applications:
* Github Issue(s) this is regarding:


**Other information**:
