### PR TITLE
Bump loader-utils to 2.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   },
   "dependencies": {
     "find-cache-dir": "^3.3.1",
-    "loader-utils": "^1.4.0",
+    "loader-utils": "^2.0.0",
     "make-dir": "^3.1.0",
     "schema-utils": "^2.6.5"
   },

--- a/src/index.js
+++ b/src/index.js
@@ -55,7 +55,7 @@ function makeLoader(callback) {
 async function loader(source, inputSourceMap, overrides) {
   const filename = this.resourcePath;
 
-  let loaderOptions = loaderUtils.getOptions(this) || {};
+  let loaderOptions = loaderUtils.getOptions(this);
 
   validateOptions(schema, loaderOptions, {
     name: "Babel loader",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2143,7 +2143,7 @@ __metadata:
     find-cache-dir: ^3.3.1
     husky: ^4.3.0
     lint-staged: ^10.5.1
-    loader-utils: ^1.4.0
+    loader-utils: ^2.0.0
     make-dir: ^3.1.0
     nyc: ^15.1.0
     pnp-webpack-plugin: ^1.6.4
@@ -5070,17 +5070,6 @@ fsevents@~2.1.2:
   languageName: node
   linkType: hard
 
-"json5@npm:^1.0.1":
-  version: 1.0.1
-  resolution: "json5@npm:1.0.1"
-  dependencies:
-    minimist: ^1.2.0
-  bin:
-    json5: lib/cli.js
-  checksum: df41624f9f40bfacc546f779eef6d161a3312fbb6ec1dbd69f8c4388e9807af653b753371ab19b6d2bab22af2ca7dde62fe03c791596acf76915e1fc4ee6fd88
-  languageName: node
-  linkType: hard
-
 "json5@npm:^2.1.2":
   version: 2.1.3
   resolution: "json5@npm:2.1.3"
@@ -5234,14 +5223,14 @@ fsevents@~2.1.2:
   languageName: node
   linkType: hard
 
-"loader-utils@npm:^1.4.0":
-  version: 1.4.0
-  resolution: "loader-utils@npm:1.4.0"
+"loader-utils@npm:^2.0.0":
+  version: 2.0.2
+  resolution: "loader-utils@npm:2.0.2"
   dependencies:
     big.js: ^5.2.2
     emojis-list: ^3.0.0
-    json5: ^1.0.1
-  checksum: 9fd690e57ad78d32ff2942383b4a7a175eba575280ba5aca3b4d03183fec34aa0db314f49bd3301adf7e60b02471644161bf53149e8f2d18fd6a52627e95a927
+    json5: ^2.1.2
+  checksum: c1df0ff0fb52787011b8d19b1e38ee1b67e31d8b301703e6f791256377ce71a6180f40c34a597dfafe76fe621139fea0ee4669344d98b939d9042ea1c32f1ba9
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
https://github.com/webpack/loader-utils/blob/master/CHANGELOG.md

New minimum required node version is 8.9.x, which is what babel-loader
already requires.

**Please check if the PR fulfills these requirements**
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Other... Please describe:

Dependency update

**Does this PR introduce a breaking change?**
- [ ] Yes
- [x] No

Closes #937 