### PR TITLE
Use md5 hashing on openssl 3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest]
-        node-version: [10.x, 12.x, 14.x, 15.x]
+        node-version: [10.x, 12.x, 14.x, 15.x, 16.x, 17.x]
         webpack-version: [latest, '4']
         include:
           - node: 14.x

--- a/src/cache.js
+++ b/src/cache.js
@@ -63,10 +63,13 @@ const write = async function (filename, compress, result) {
  * @return {String}
  */
 const filename = function (source, identifier, options) {
-  // md4 hashing is not supported starting with node v17.0.0
-  const majorNodeVersion = parseInt(process.versions.node.split(".")[0], 10);
+  // md4 hashing is not supported by default in openssl 3
+  const majorOpensslVersion = parseInt(
+    process.versions.openssl.split(".")[0],
+    10,
+  );
   let hashType = "md4";
-  if (majorNodeVersion >= 17) {
+  if (majorOpensslVersion >= 3) {
     hashType = "md5";
   }
 


### PR DESCRIPTION
Fixes https://github.com/babel/babel-loader/issues/923

Webpack will use xxhash64 so that's an option too - wdyt?

* https://webpack.js.org/configuration/output/#outputhashfunction
* https://github.com/webpack/webpack/issues/14532#issuecomment-947525539

I also agree that falling back isn't ideal - what about using md5 or xxhash64 for all?