### PR TITLE
ci: add node v18 to test workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest]
-        node-version: [10.x, 12.x, 14.x, 16.x, 18.x]
+        node-version: [10.x, 12.x, 14.x, 15.x, 16.x, 18.x]
         webpack-version: [latest, '4']
         include:
           - node: 14.x

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest]
-        node-version: [10.x, 12.x, 14.x, 15.x]
+        node-version: [10.x, 12.x, 14.x, 16.x, 18.x]
         webpack-version: [latest, '4']
         include:
           - node: 14.x

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest]
-        node-version: [10.x, 12.x, 14.x, 15.x, 16.x, 18.x]
+        node-version: [10.x, 12.x, 14.x, 16.x, 18.x]
         webpack-version: [latest, '4']
         include:
           - node: 14.x


### PR DESCRIPTION
Add node 16.x & 18.x to test workflow.

**Please Read the [CONTRIBUTING Guidelines](https://github.com/babel/babel-loader/blob/main/CONTRIBUTING.md)**
*In particular the portion on Commit Message Formatting*

**Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)
  Node 16.x and v18.x are not included in the test workflow.
  
**What is the new behavior?**
  Added node 16.x and v18.x to test workflow.

**Does this PR introduce a breaking change?**
- [ ] Yes
- [x] No