### PR TITLE
feat: expose webpack.target as rawTarget

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -161,8 +161,9 @@ async function loader(source, inputSourceMap, overrides) {
 
   // babel.loadPartialConfigAsync is available in v7.8.0+
   const { loadPartialConfigAsync = babel.loadPartialConfig } = babel;
+  const rawTarget = this._compilation.options.target;
   const config = await loadPartialConfigAsync(
-    injectCaller(programmaticOptions, this.target),
+    injectCaller(programmaticOptions, this.target, rawTarget),
   );
   if (config) {
     let options = config.options;

--- a/src/injectCaller.js
+++ b/src/injectCaller.js
@@ -1,12 +1,13 @@
 const babel = require("@babel/core");
 
-module.exports = function injectCaller(opts, target) {
+module.exports = function injectCaller(opts, target, rawTarget) {
   if (!supportsCallerOption()) return opts;
 
   return Object.assign({}, opts, {
     caller: Object.assign(
       {
         name: "babel-loader",
+        rawTarget,
 
         // Provide plugins with insight into webpack target.
         // https://github.com/babel/babel-loader/issues/787


### PR DESCRIPTION
**Please Read the [CONTRIBUTING Guidelines](https://github.com/babel/babel-loader/blob/main/CONTRIBUTING.md)**
*In particular the portion on Commit Message Formatting*

**Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)

Currently the target exposed via `caller.target` is the normalized target.

**What is the new behavior?**

 This change adds a new property called `rawTarget` that exposes the original target as set on the webpack configuration.


**Does this PR introduce a breaking change?**
- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the following...

* Impact:
* Migration path for existing applications:
* Github Issue(s) this is regarding:


**Other information**:

In the future, I think [browserlistEnv](https://babeljs.io/docs/en/options#browserslistenv) option could be automatically set when the webpack's [target](https://webpack.js.org/configuration/target/#browserslist) option is set using `browserslist:${env}`. I believe that would make the webpack / babel / browserslist integration easier.

I'm afraid that would be a breaking change, and since there are, based on the [documentation](https://babeljs.io/docs/en/options#no-targets), future breaking changes it might make sense to wait for that to introduce this automatic `browserlistEnv` setting.