### PR TITLE
Bump babel and node versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,9 +8,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-node@v1
+      - uses: actions/setup-node@v3
         with:
-          node-version: "*"
+          node-version: latest
       - name: Install dependencies
         run: yarn
       - name: Lint
@@ -20,7 +20,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest]
-        node-version: [12.x, 14.x, 16.x]
+        node-version: [14.x, 16.x]
         webpack-version: [latest, '4']
         include:
           - node-version: 18.x
@@ -31,7 +31,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node-version }}
       - name: Install dependencies
@@ -49,29 +49,4 @@ jobs:
         if: ${{ matrix.coverage }}
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
-  test-legacy:
-    name: Test - ubuntu-latest - Node v8.9, Webpack 4
-    runs-on: ubuntu-latest
-    env:
-      YARN_NODE_LINKER: node-modules
-    steps:
-      - uses: actions/checkout@v2
-      - name: Use Node.js latest
-        uses: actions/setup-node@v1
-        with:
-          node-version: '*'
-      - name: Install dependencies
-        run: yarn
-      - name: Install webpack 4
-        run: yarn add -D webpack@4
-      - name: Build babel-loader
-        run: yarn run build
-        env:
-          BABEL_ENV: test
-      - name: Use Node.js 8.9
-        uses: actions/setup-node@v1
-        with:
-          node-version: '8.9'
-      - name: Run tests for webpack version 4
-        run: node scripts/test-legacy
 

--- a/package.json
+++ b/package.json
@@ -12,7 +12,6 @@
   "dependencies": {
     "find-cache-dir": "^3.3.2",
     "loader-utils": "^2.0.0",
-    "make-dir": "^3.1.0",
     "schema-utils": "^4.0.0"
   },
   "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -7,16 +7,16 @@
   ],
   "main": "lib/index.js",
   "engines": {
-    "node": ">= 8.9"
+    "node": ">= 14.15.0"
   },
   "dependencies": {
-    "find-cache-dir": "^3.3.1",
+    "find-cache-dir": "^3.3.2",
     "loader-utils": "^2.0.0",
     "make-dir": "^3.1.0",
-    "schema-utils": "^2.6.5"
+    "schema-utils": "^4.0.0"
   },
   "peerDependencies": {
-    "@babel/core": "^7.0.0",
+    "@babel/core": "^7.12.0",
     "webpack": ">=2"
   },
   "devDependencies": {

--- a/src/cache.js
+++ b/src/cache.js
@@ -7,13 +7,13 @@
  * @see https://github.com/babel/babel-loader/issues/34
  * @see https://github.com/babel/babel-loader/pull/41
  */
-const fs = require("fs");
 const os = require("os");
 const path = require("path");
 const zlib = require("zlib");
 const crypto = require("crypto");
 const findCacheDir = require("find-cache-dir");
 const { promisify } = require("util");
+const { readFile, writeFile, mkdir } = require("node:fs/promises");
 
 const transform = require("./transform");
 // Lazily instantiated when needed
@@ -27,11 +27,8 @@ try {
   hashType = "md5";
 }
 
-const readFile = promisify(fs.readFile);
-const writeFile = promisify(fs.writeFile);
 const gunzip = promisify(zlib.gunzip);
 const gzip = promisify(zlib.gzip);
-const makeDir = require("make-dir");
 
 /**
  * Read the contents from the compressed file.
@@ -108,7 +105,8 @@ const handleCache = async function (directory, params) {
 
   // Make sure the directory exists.
   try {
-    await makeDir(directory);
+    // overwrite directory if exists
+    await mkdir(directory, { recursive: true });
   } catch (err) {
     if (fallback) {
       return handleCache(os.tmpdir(), params);

--- a/src/index.js
+++ b/src/index.js
@@ -4,7 +4,7 @@ try {
 } catch (err) {
   if (err.code === "MODULE_NOT_FOUND") {
     err.message +=
-      "\n babel-loader@8 requires Babel 7.x (the package '@babel/core'). " +
+      "\n babel-loader@9 requires Babel 7.12+ (the package '@babel/core'). " +
       "If you'd like to use Babel 6.x ('babel-core'), you should install 'babel-loader@7'.";
   }
   throw err;
@@ -14,7 +14,7 @@ try {
 // people useful feedback if they try to use it alongside babel-loader.
 if (/^6\./.test(babel.version)) {
   throw new Error(
-    "\n babel-loader@8 will not work with the '@babel/core@6' bridge package. " +
+    "\n babel-loader@9 will not work with the '@babel/core@6' bridge package. " +
       "If you want to use Babel 6.x, install 'babel-loader@7'.",
   );
 }
@@ -151,17 +151,7 @@ async function loader(source, inputSourceMap, overrides) {
   delete programmaticOptions.cacheCompression;
   delete programmaticOptions.metadataSubscribers;
 
-  if (!babel.loadPartialConfig) {
-    throw new Error(
-      `babel-loader ^8.0.0-beta.3 requires @babel/core@7.0.0-beta.41, but ` +
-        `you appear to be using "${babel.version}". Either update your ` +
-        `@babel/core version, or pin you babel-loader version to 8.0.0-beta.2`,
-    );
-  }
-
-  // babel.loadPartialConfigAsync is available in v7.8.0+
-  const { loadPartialConfigAsync = babel.loadPartialConfig } = babel;
-  const config = await loadPartialConfigAsync(
+  const config = await babel.loadPartialConfigAsync(
     injectCaller(programmaticOptions, this.target),
   );
   if (config) {
@@ -209,20 +199,7 @@ async function loader(source, inputSourceMap, overrides) {
       result = await transform(source, options);
     }
 
-    // Availabe since Babel 7.12
-    // https://github.com/babel/babel/pull/11907
-    if (config.files) {
-      config.files.forEach(configFile => this.addDependency(configFile));
-    } else {
-      // .babelrc.json
-      if (typeof config.babelrc === "string") {
-        this.addDependency(config.babelrc);
-      }
-      // babel.config.js
-      if (config.config) {
-        this.addDependency(config.config);
-      }
-    }
+    config.files.forEach(configFile => this.addDependency(configFile));
 
     if (result) {
       if (overrides && overrides.result) {

--- a/src/index.js
+++ b/src/index.js
@@ -27,7 +27,7 @@ const schema = require("./schema");
 
 const { isAbsolute } = require("path");
 const loaderUtils = require("loader-utils");
-const validateOptions = require("schema-utils");
+const validateOptions = require("schema-utils").validate;
 
 function subscribe(subscriber, metadata, context) {
   if (context[subscriber]) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1461,10 +1461,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/json-schema@npm:*, @types/json-schema@npm:^7.0.5, @types/json-schema@npm:^7.0.6":
-  version: 7.0.6
-  resolution: "@types/json-schema@npm:7.0.6"
-  checksum: 3b1e5e049b065a41d2bc1f0c16e01dac5a4a1276bbe8b413657298f574d64a955d3b10bec9e7796fde0927f307e6fedbac1cf4da3604593c431899eea3ad0756
+"@types/json-schema@npm:*, @types/json-schema@npm:^7.0.6, @types/json-schema@npm:^7.0.9":
+  version: 7.0.11
+  resolution: "@types/json-schema@npm:7.0.11"
+  checksum: 527bddfe62db9012fccd7627794bd4c71beb77601861055d87e3ee464f2217c85fca7a4b56ae677478367bbd248dbde13553312b7d4dbc702a2f2bbf60c4018d
   languageName: node
   linkType: hard
 
@@ -1749,12 +1749,37 @@ __metadata:
   languageName: node
   linkType: hard
 
+"ajv-formats@npm:^2.1.1":
+  version: 2.1.1
+  resolution: "ajv-formats@npm:2.1.1"
+  dependencies:
+    ajv: ^8.0.0
+  peerDependencies:
+    ajv: ^8.0.0
+  peerDependenciesMeta:
+    ajv:
+      optional: true
+  checksum: 4a287d937f1ebaad4683249a4c40c0fa3beed30d9ddc0adba04859026a622da0d317851316ea64b3680dc60f5c3c708105ddd5d5db8fe595d9d0207fd19f90b7
+  languageName: node
+  linkType: hard
+
 "ajv-keywords@npm:^3.5.2":
   version: 3.5.2
   resolution: "ajv-keywords@npm:3.5.2"
   peerDependencies:
     ajv: ^6.9.1
   checksum: 7dc5e5931677a680589050f79dcbe1fefbb8fea38a955af03724229139175b433c63c68f7ae5f86cf8f65d55eb7c25f75a046723e2e58296707617ca690feae9
+  languageName: node
+  linkType: hard
+
+"ajv-keywords@npm:^5.0.0":
+  version: 5.1.0
+  resolution: "ajv-keywords@npm:5.1.0"
+  dependencies:
+    fast-deep-equal: ^3.1.3
+  peerDependencies:
+    ajv: ^8.8.2
+  checksum: c35193940b853119242c6757787f09ecf89a2c19bcd36d03ed1a615e710d19d450cb448bfda407b939aba54b002368c8bff30529cc50a0536a8e10bcce300421
   languageName: node
   linkType: hard
 
@@ -1767,6 +1792,18 @@ __metadata:
     json-schema-traverse: ^0.4.1
     uri-js: ^4.2.2
   checksum: 874972efe5c4202ab0a68379481fbd3d1b5d0a7bd6d3cc21d40d3536ebff3352a2a1fabb632d4fd2cc7fe4cbdcd5ed6782084c9bbf7f32a1536d18f9da5007d4
+  languageName: node
+  linkType: hard
+
+"ajv@npm:^8.0.0, ajv@npm:^8.8.0":
+  version: 8.11.0
+  resolution: "ajv@npm:8.11.0"
+  dependencies:
+    fast-deep-equal: ^3.1.1
+    json-schema-traverse: ^1.0.0
+    require-from-string: ^2.0.2
+    uri-js: ^4.2.2
+  checksum: 5e0ff226806763be73e93dd7805b634f6f5921e3e90ca04acdf8db81eed9d8d3f0d4c5f1213047f45ebbf8047ffe0c840fa1ef2ec42c3a644899f69aa72b5bef
   languageName: node
   linkType: hard
 
@@ -2140,7 +2177,7 @@ __metadata:
     eslint-config-prettier: ^6.3.0
     eslint-plugin-flowtype: ^5.2.0
     eslint-plugin-prettier: ^3.0.0
-    find-cache-dir: ^3.3.1
+    find-cache-dir: ^3.3.2
     husky: ^4.3.0
     lint-staged: ^10.5.1
     loader-utils: ^2.0.0
@@ -2152,11 +2189,11 @@ __metadata:
     react-intl: ^5.9.4
     react-intl-webpack-plugin: ^0.3.0
     rimraf: ^3.0.0
-    schema-utils: ^2.6.5
+    schema-utils: ^4.0.0
     semver: 7.3.2
     webpack: ^5.34.0
   peerDependencies:
-    "@babel/core": ^7.0.0
+    "@babel/core": ^7.12.0
     webpack: ">=2"
   languageName: unknown
   linkType: soft
@@ -3683,7 +3720,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fast-deep-equal@npm:^3.1.1":
+"fast-deep-equal@npm:^3.1.1, fast-deep-equal@npm:^3.1.3":
   version: 3.1.3
   resolution: "fast-deep-equal@npm:3.1.3"
   checksum: e21a9d8d84f53493b6aa15efc9cfd53dd5b714a1f23f67fb5dc8f574af80df889b3bce25dc081887c6d25457cce704e636395333abad896ccdec03abaf1f3f9d
@@ -3787,14 +3824,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"find-cache-dir@npm:^3.2.0, find-cache-dir@npm:^3.3.1":
-  version: 3.3.1
-  resolution: "find-cache-dir@npm:3.3.1"
+"find-cache-dir@npm:^3.2.0, find-cache-dir@npm:^3.3.2":
+  version: 3.3.2
+  resolution: "find-cache-dir@npm:3.3.2"
   dependencies:
     commondir: ^1.0.1
     make-dir: ^3.0.2
     pkg-dir: ^4.1.0
-  checksum: 0f7c22b65e07f9b486b4560227d014fab1e79ffbbfbafb87d113a2e878510bd620ef6fdff090e5248bb2846d28851d19e42bfdc7c50687966acc106328e7abf1
+  checksum: 1e61c2e64f5c0b1c535bd85939ae73b0e5773142713273818cc0b393ee3555fb0fd44e1a5b161b8b6c3e03e98c2fcc9c227d784850a13a90a8ab576869576817
   languageName: node
   linkType: hard
 
@@ -5048,6 +5085,13 @@ fsevents@~2.1.2:
   version: 0.4.1
   resolution: "json-schema-traverse@npm:0.4.1"
   checksum: 7486074d3ba247769fda17d5181b345c9fb7d12e0da98b22d1d71a5db9698d8b4bd900a3ec1a4ffdd60846fc2556274a5c894d0c48795f14cb03aeae7b55260b
+  languageName: node
+  linkType: hard
+
+"json-schema-traverse@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "json-schema-traverse@npm:1.0.0"
+  checksum: 02f2f466cdb0362558b2f1fd5e15cce82ef55d60cd7f8fa828cf35ba74330f8d767fcae5c5c2adb7851fa811766c694b9405810879bc4e1ddd78a7c0e03658ad
   languageName: node
   linkType: hard
 
@@ -6608,6 +6652,13 @@ fsevents@~2.1.2:
   languageName: node
   linkType: hard
 
+"require-from-string@npm:^2.0.2":
+  version: 2.0.2
+  resolution: "require-from-string@npm:2.0.2"
+  checksum: a03ef6895445f33a4015300c426699bc66b2b044ba7b670aa238610381b56d3f07c686251740d575e22f4c87531ba662d06937508f0f3c0f1ddc04db3130560b
+  languageName: node
+  linkType: hard
+
 "require-main-filename@npm:^2.0.0":
   version: 2.0.0
   resolution: "require-main-filename@npm:2.0.0"
@@ -6766,7 +6817,19 @@ fsevents@~2.1.2:
   languageName: node
   linkType: hard
 
-"schema-utils@npm:*, schema-utils@npm:^3.0.0":
+"schema-utils@npm:*, schema-utils@npm:^4.0.0":
+  version: 4.0.0
+  resolution: "schema-utils@npm:4.0.0"
+  dependencies:
+    "@types/json-schema": ^7.0.9
+    ajv: ^8.8.0
+    ajv-formats: ^2.1.1
+    ajv-keywords: ^5.0.0
+  checksum: c843e92fdd1a5c145dbb6ffdae33e501867f9703afac67bdf35a685e49f85b1dcc10ea250033175a64bd9d31f0555bc6785b8359da0c90bcea30cf6dfbb55a8f
+  languageName: node
+  linkType: hard
+
+"schema-utils@npm:^3.0.0":
   version: 3.0.0
   resolution: "schema-utils@npm:3.0.0"
   dependencies:
@@ -6774,17 +6837,6 @@ fsevents@~2.1.2:
     ajv: ^6.12.5
     ajv-keywords: ^3.5.2
   checksum: 56dc93b4f6abe91aa2b76b2c656610cc6d491297f4e6866340bc7b6b226b521a2969ab2498cd9e6c59eda670b730a9c8695404ca56c08643c3b95c5e174588c8
-  languageName: node
-  linkType: hard
-
-"schema-utils@npm:^2.6.5":
-  version: 2.7.1
-  resolution: "schema-utils@npm:2.7.1"
-  dependencies:
-    "@types/json-schema": ^7.0.5
-    ajv: ^6.12.4
-    ajv-keywords: ^3.5.2
-  checksum: 32c62fc9e28edd101e1bd83453a4216eb9bd875cc4d3775e4452b541908fa8f61a7bbac8ffde57484f01d7096279d3ba0337078e85a918ecbeb72872fb09fb2b
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2181,7 +2181,6 @@ __metadata:
     husky: ^4.3.0
     lint-staged: ^10.5.1
     loader-utils: ^2.0.0
-    make-dir: ^3.1.0
     nyc: ^15.1.0
     pnp-webpack-plugin: ^1.6.4
     prettier: ^2.1.2
@@ -5390,7 +5389,7 @@ fsevents@~2.1.2:
   languageName: node
   linkType: hard
 
-"make-dir@npm:^3.0.0, make-dir@npm:^3.0.2, make-dir@npm:^3.1.0":
+"make-dir@npm:^3.0.0, make-dir@npm:^3.0.2":
   version: 3.1.0
   resolution: "make-dir@npm:3.1.0"
   dependencies:


### PR DESCRIPTION
**Please Read the [CONTRIBUTING Guidelines](https://github.com/babel/babel-loader/blob/main/CONTRIBUTING.md)**
*In particular the portion on Commit Message Formatting*

**Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**Does this PR introduce a breaking change?**
- [x] Yes
- [ ] No

babel-loader 9 now requires Node.js 14.15.0 and Babel 7.12.0. 14.15.0 is the first Fermium LTS version, which is the earliest supported Node version as of Oct 2022.

* Impact: Medium
* Migration path for existing applications: Upgrade to minimum supported Node version 14.15.0 and Babel 7.12.0

Closes #933