### PR TITLE
remove "node:" builtin prefix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,9 @@ jobs:
         node-version: [14, 16, 18]
         webpack-version: ['5']
         include:
+          - node-version: "14.15.0" # The minimum supported node version
+            webpack-version: latest
+            os: ubuntu-latest
           - node-version: latest
             webpack-version: latest
             os: ubuntu-latest

--- a/src/cache.js
+++ b/src/cache.js
@@ -13,7 +13,7 @@ const zlib = require("zlib");
 const crypto = require("crypto");
 const findCacheDir = require("find-cache-dir");
 const { promisify } = require("util");
-const { readFile, writeFile, mkdir } = require("node:fs/promises");
+const { readFile, writeFile, mkdir } = require("fs/promises");
 
 const transform = require("./transform");
 // Lazily instantiated when needed


### PR DESCRIPTION
**Please Read the [CONTRIBUTING Guidelines](https://github.com/babel/babel-loader/blob/main/CONTRIBUTING.md)**
*In particular the portion on Commit Message Formatting*

**Please check if the PR fulfills these requirements**
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)

`babel-loader` is failing on Node.js 14.15

**What is the new behavior?**

it should work now.

**Does this PR introduce a breaking change?**
- [ ] Yes
- [x] No

**Other information**:

Fixes #969. 

Per https://nodejs.org/docs/latest-v14.x/api/esm.html#esm_node_imports, `require("node:...")` is supported since Node.js 14.18, since we still support 14.15.0 we should remove the `node:` import specifier prefix
