### PR TITLE
Pass external dependencies from Babel to Webpack

### DIFF
--- a/src/cache.js
+++ b/src/cache.js
@@ -119,15 +119,19 @@ const handleCache = async function (directory, params) {
   // return it to the user asap and write it in cache
   const result = await transform(source, options);
 
-  try {
-    await write(file, cacheCompression, result);
-  } catch (err) {
-    if (fallback) {
-      // Fallback to tmpdir if node_modules folder not writable
-      return handleCache(os.tmpdir(), params);
-    }
+  // Do not cache if there are external dependencies,
+  // since they might change and we cannot control it.
+  if (!result.externalDependencies.length) {
+    try {
+      await write(file, cacheCompression, result);
+    } catch (err) {
+      if (fallback) {
+        // Fallback to tmpdir if node_modules folder not writable
+        return handleCache(os.tmpdir(), params);
+      }
 
-    throw err;
+      throw err;
+    }
   }
 
   return result;

--- a/src/index.js
+++ b/src/index.js
@@ -210,8 +210,9 @@ async function loader(source, inputSourceMap, overrides) {
         });
       }
 
-      const { code, map, metadata } = result;
+      const { code, map, metadata, externalDependencies } = result;
 
+      externalDependencies?.forEach(dep => this.addDependency(dep));
       metadataSubscribers.forEach(subscriber => {
         subscribe(subscriber, metadata, this);
       });

--- a/src/transform.js
+++ b/src/transform.js
@@ -19,13 +19,21 @@ module.exports = async function (source, options) {
   // https://github.com/babel/babel/blob/main/packages/babel-core/src/transformation/index.js
   // For discussion on this topic see here:
   // https://github.com/babel/babel-loader/pull/629
-  const { ast, code, map, metadata, sourceType } = result;
+  const { ast, code, map, metadata, sourceType, externalDependencies } = result;
 
   if (map && (!map.sourcesContent || !map.sourcesContent.length)) {
     map.sourcesContent = [source];
   }
 
-  return { ast, code, map, metadata, sourceType };
+  return {
+    ast,
+    code,
+    map,
+    metadata,
+    sourceType,
+    // Convert it from a Set to an Array to make it JSON-serializable.
+    externalDependencies: Array.from(externalDependencies || []),
+  };
 };
 
 module.exports.version = babel.version;

--- a/test/loader.test.js
+++ b/test/loader.test.js
@@ -184,3 +184,38 @@ test.cb("should load ESM config files", t => {
     t.end();
   });
 });
+
+test.cb("should track external dependencies", t => {
+  const dep = path.join(__dirname, "fixtures/metadata.js");
+  const config = Object.assign({}, globalConfig, {
+    entry: path.join(__dirname, "fixtures/constant.js"),
+    output: {
+      path: t.context.directory,
+    },
+    module: {
+      rules: [
+        {
+          test: /\.js$/,
+          loader: babelLoader,
+          options: {
+            babelrc: false,
+            configFile: false,
+            plugins: [
+              api => {
+                api.cache.never();
+                api.addExternalDependency(dep);
+                return { visitor: {} };
+              },
+            ],
+          },
+        },
+      ],
+    },
+  });
+
+  webpack(config, (err, stats) => {
+    t.true(stats.compilation.fileDependencies.has(dep));
+    t.deepEqual(stats.compilation.warnings, []);
+    t.end();
+  });
+});


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
- [x] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)
**What is the new behavior?**

We added support for `externalDependencies` in Babel 7.12.0, but we never properly wired it in `babel-loader`. `babel-loader` must forward the list of external dependencies from `@babel/core` to `webpack`, so that webpack knows which files to watch and when to re-run Babel.

**Does this PR introduce a breaking change?**
- [ ] Yes
- [x] No
