### PR TITLE
Fix esm compatibility with jest

### DIFF
--- a/src/cache.js
+++ b/src/cache.js
@@ -13,7 +13,6 @@ const zlib = require("zlib");
 const crypto = require("crypto");
 const { promisify } = require("util");
 const { readFile, writeFile, mkdir } = require("fs/promises");
-const findCacheDirP = import("find-cache-dir");
 
 const transform = require("./transform");
 // Lazily instantiated when needed
@@ -169,7 +168,7 @@ module.exports = async function (params) {
     directory = params.cacheDirectory;
   } else {
     if (defaultCacheDirectory === null) {
-      const { default: findCacheDir } = await findCacheDirP;
+      const { default: findCacheDir } = await import("find-cache-dir");
       defaultCacheDirectory =
         findCacheDir({ name: "babel-loader" }) || os.tmpdir();
     }


### PR DESCRIPTION
**What kind of change does this PR introduce?**
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?**

Steps to reproduce:
1. Create `package.json` file
```json
{
  "scripts": {
    "test": "jest"
  },
  "devDependencies": {
    "babel-loader": "9.1.3",
    "jest": "29.6.2"
  }
}
```
2. Create `babel.test.js` file
```js
test('should import babel-loader correctly', () => {
  expect(require('babel-loader')).toBeInstanceOf(Function);
});
```
3. Run test
Test fail: `Error: You need to run with a version of node that supports ES Modules in the VM API. See https://jestjs.io/docs/ecmascript-modules`

**What is the new behavior?**

The test pass successfully
![image](https://github.com/babel/babel-loader/assets/12452003/bdc5a891-7e0a-4ba6-8b8f-a98219a6185e)

**Does this PR introduce a breaking change?**
- [ ] Yes
- [x] No
