### PR TITLE
bump node requirement to `^18.20.0 || ^20.10.0 || >=22.0.0` and webpack requirement to `>= 5.61.0`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,10 +11,10 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest]
-        node-version: [14, 16, 18, 20]
+        node-version: [18, 20, 22]
         webpack-version: ["5"]
         include:
-          - node-version: "14.15.0" # The minimum supported node version
+          - node-version: "18.20.0" # The minimum supported node version
             webpack-version: "5.0.0" # The minimum supported webpack version
             os: ubuntu-latest
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
         webpack-version: ["5"]
         include:
           - node-version: "18.20.0" # The minimum supported node version
-            webpack-version: "5.0.0" # The minimum supported webpack version
+            webpack-version: "5.61.0" # The minimum supported webpack version
             os: ubuntu-latest
     runs-on: ${{ matrix.os }}
     steps:

--- a/babel.config.json
+++ b/babel.config.json
@@ -18,7 +18,7 @@
     "superIsCallableConstructor": true
   },
   "targets": {
-    "node": "14.15.0"
+    "node": "18.20.0"
   },
   "presets": [
     [

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   },
   "peerDependencies": {
     "@babel/core": "^7.12.0",
-    "webpack": ">=5"
+    "webpack": ">=5.61.0"
   },
   "devDependencies": {
     "@ava/babel": "^1.0.1",
@@ -32,7 +32,7 @@
     "husky": "^8.0.3",
     "lint-staged": "^13.2.3",
     "prettier": "^3.0.0",
-    "webpack": "^5.89.0"
+    "webpack": "^5.93.0"
   },
   "scripts": {
     "clean": "node ./scripts/rimraf.mjs lib",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   ],
   "main": "lib/index.js",
   "engines": {
-    "node": ">= 14.15.0"
+    "node": "^18.20.0 || ^20.10.0 || >=22.0.0"
   },
   "dependencies": {
     "find-cache-dir": "^4.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2289,10 +2289,10 @@ __metadata:
     lint-staged: ^13.2.3
     prettier: ^3.0.0
     schema-utils: ^4.0.0
-    webpack: ^5.89.0
+    webpack: ^5.93.0
   peerDependencies:
     "@babel/core": ^7.12.0
-    webpack: ">=5"
+    webpack: ">=5.61.0"
   languageName: unknown
   linkType: soft
 
@@ -6805,9 +6805,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"webpack@npm:^5.89.0":
-  version: 5.92.1
-  resolution: "webpack@npm:5.92.1"
+"webpack@npm:^5.93.0":
+  version: 5.93.0
+  resolution: "webpack@npm:5.93.0"
   dependencies:
     "@types/eslint-scope": ^3.7.3
     "@types/estree": ^1.0.5
@@ -6838,7 +6838,7 @@ __metadata:
       optional: true
   bin:
     webpack: bin/webpack.js
-  checksum: 11bec781260c4180883e98a4a15a08df297aca654ded45e70598f688881dd722f992d680addafe6f6342debede345cddcce2b781c50f5cde29d6c0bc33a82452
+  checksum: c93bd73d9e1ab49b07e139582187f1c3760ee2cf0163b6288fab2ae210e39e59240a26284e7e5d29bec851255ef4b43c51642c882fa5a94e16ce7cb906deeb47
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
**Please Read the [CONTRIBUTING Guidelines](https://github.com/babel/babel-loader/blob/main/CONTRIBUTING.md)**
*In particular the portion on Commit Message Formatting*

**Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)
Behaviour is not expected to change.


**What is the new behavior?**



**Does this PR introduce a breaking change?**
- [x] Yes
- [ ] No

If this PR contains a breaking change, please describe the following...

* Impact: Medium
  Dropped support for dead node.js versions and old webpack 5 versions.
* Migration path for existing applications: Upgrade node.js to `^18.20.0 || ^20.10.0 || >=22.0.0` and webpack to `>= 5.61.0` or pin babel-loader to 9
* Github Issue(s) this is regarding:


**Other information**:
The webpack requirement is bumped to 5.61.0 as this is the first webpack version that supports the Node.js 18 change without the `--openssl-legacy-provider` switch: https://github.com/webpack/webpack/commit/0f6c78cca174a73184fdc0d9c9c2bd376b48557c