### PR TITLE
breaking: use output.hashFunction as loader cache

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -181,6 +181,9 @@ async function loader(source, inputSourceMap, overrides) {
 
     let result;
     if (cacheDirectory) {
+      const hash = this.utils.createHash(
+        this._compilation.outputOptions.hashFunction,
+      );
       result = await cache({
         source,
         options,
@@ -188,6 +191,7 @@ async function loader(source, inputSourceMap, overrides) {
         cacheDirectory,
         cacheIdentifier,
         cacheCompression,
+        hash,
       });
     } else {
       result = await transform(source, options);


### PR DESCRIPTION
**Please Read the [CONTRIBUTING Guidelines](https://github.com/babel/babel-loader/blob/main/CONTRIBUTING.md)**
*In particular the portion on Commit Message Formatting*

**Please check if the PR fulfills these requirements**
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)
The babel-loader hash function can not be changed by users. It will use `sha256` and then fallback to `md5`.


**What is the new behavior?**
The hash function is now determined by the webpack option `output.hashFunction`. This opens the door to more performant hash such as the future webpack defaults `xxhash64`. Plus we don't have to update the hash function again if in the future OpenSSL drops more unsafe crypto hash functions, since users can provide the desired `hashFunction` in the webpack config.

**Does this PR introduce a breaking change?**
- [x] Yes
- [ ] No

If this PR contains a breaking change, please describe the following...

The cache filename might be changed because now it aligns to the webpack option `output.hashFunction`, which may be different than our previous hash function choice.

* Impact: Low
* Migration path for existing applications: purge the babel-loader cache before upgrading babel-loader. If they are not purged, the function of babel-loader will not be impacted but doing so will save some disk space.
* Github Issue(s) this is regarding:


**Other information**:
