### PR TITLE
refactor: use webpack builtin schema util

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,8 +10,7 @@
     "node": "^18.20.0 || ^20.10.0 || >=22.0.0"
   },
   "dependencies": {
-    "find-cache-dir": "^4.0.0",
-    "schema-utils": "^4.0.0"
+    "find-cache-dir": "^4.0.0"
   },
   "peerDependencies": {
     "@babel/core": "^7.12.0",

--- a/src/index.js
+++ b/src/index.js
@@ -26,7 +26,6 @@ const injectCaller = require("./injectCaller");
 const schema = require("./schema");
 
 const { isAbsolute } = require("path");
-const validateOptions = require("schema-utils").validate;
 
 function subscribe(subscriber, metadata, context) {
   if (context[subscriber]) {
@@ -54,17 +53,9 @@ function makeLoader(callback) {
 async function loader(source, inputSourceMap, overrides) {
   const filename = this.resourcePath;
 
-  let loaderOptions = this.getOptions();
-  validateOptions(schema, loaderOptions, {
-    name: "Babel loader",
-  });
+  let loaderOptions = this.getOptions(schema);
 
   if (loaderOptions.customize != null) {
-    if (typeof loaderOptions.customize !== "string") {
-      throw new Error(
-        "Customized loaders must be implemented as standalone modules.",
-      );
-    }
     if (!isAbsolute(loaderOptions.customize)) {
       throw new Error(
         "Customized loaders must be passed as absolute paths, since " +
@@ -99,17 +90,21 @@ async function loader(source, inputSourceMap, overrides) {
 
   // Deprecation handling
   if ("forceEnv" in loaderOptions) {
-    console.warn(
-      "The option `forceEnv` has been removed in favor of `envName` in Babel 7.",
+    this.emitWarning(
+      new Error(
+        "The option `forceEnv` has been removed in favor of `envName` in Babel 7.",
+      ),
     );
   }
   if (typeof loaderOptions.babelrc === "string") {
-    console.warn(
-      "The option `babelrc` should not be set to a string anymore in the babel-loader config. " +
-        "Please update your configuration and set `babelrc` to true or false.\n" +
-        "If you want to specify a specific babel config file to inherit config from " +
-        "please use the `extends` option.\nFor more information about this options see " +
-        "https://babeljs.io/docs/core-packages/#options",
+    this.emitWarning(
+      new Error(
+        "The option `babelrc` should not be set to a string anymore in the babel-loader config. " +
+          "Please update your configuration and set `babelrc` to true or false.\n" +
+          "If you want to specify a specific babel config file to inherit config from " +
+          "please use the `extends` option.\nFor more information about this options see " +
+          "https://babeljs.io/docs/#options",
+      ),
     );
   }
 

--- a/src/schema.json
+++ b/src/schema.json
@@ -1,8 +1,9 @@
 {
+  "title": "Babel Loader options",
   "type": "object",
   "properties": {
     "cacheDirectory": {
-      "oneOf": [
+      "anyOf": [
         {
           "type": "boolean"
         },
@@ -20,8 +21,18 @@
       "default": true
     },
     "customize": {
-      "type": "string",
+      "anyOf": [
+        {
+          "type": "null"
+        },
+        {
+          "type": "string"
+        }
+      ],
       "default": null
+    },
+    "metadataSubscribers": {
+      "type": "array"
     }
   },
   "additionalProperties": true

--- a/test/options.test.js
+++ b/test/options.test.js
@@ -63,3 +63,148 @@ test("should interpret options given to the loader", async () => {
   const files = fs.readdirSync(outputDir);
   assert.ok(files.length > 0);
 });
+
+test("should throw when options.metadataSubscribers is not an array", async () => {
+  const config = Object.assign({}, globalConfig, {
+    output: {
+      path: context.directory,
+    },
+    module: {
+      rules: [
+        {
+          test: /\.jsx?/,
+          loader: babelLoader,
+          exclude: /node_modules/,
+          options: {
+            metadataSubscribers: function subscriber() {},
+          },
+        },
+      ],
+    },
+  });
+  const stats = await webpackAsync(config);
+  const { errors } = stats.compilation;
+  assert.deepEqual(errors.length, 1);
+  const errorMessage = errors[0].message;
+  assert.match(
+    errorMessage,
+    /ValidationError: Invalid options object\. Babel Loader has been initialized using an options object that does not match the API schema\./,
+  );
+  assert.match(errorMessage, /options\.metadataSubscribers should be an array/);
+});
+
+test("should throw when options.customize is not a string", async () => {
+  const config = Object.assign({}, globalConfig, {
+    output: {
+      path: context.directory,
+    },
+    module: {
+      rules: [
+        {
+          test: /\.jsx?/,
+          loader: babelLoader,
+          exclude: /node_modules/,
+          options: {
+            customize: true,
+          },
+        },
+      ],
+    },
+  });
+  const stats = await webpackAsync(config);
+  const { errors } = stats.compilation;
+  assert.deepEqual(errors.length, 1);
+  const errorMessage = errors[0].message;
+  assert.match(
+    errorMessage,
+    /ValidationError: Invalid options object\. Babel Loader has been initialized using an options object that does not match the API schema\./,
+  );
+  assert.match(
+    errorMessage,
+    /options\.customize should be one of these:\s null | string/,
+  );
+});
+
+test("should throw when options.customize is not an absolute path", async () => {
+  const config = Object.assign({}, globalConfig, {
+    output: {
+      path: context.directory,
+    },
+    module: {
+      rules: [
+        {
+          test: /\.jsx?/,
+          loader: babelLoader,
+          exclude: /node_modules/,
+          options: {
+            customize: "./node_modules/babel-loader-customized",
+          },
+        },
+      ],
+    },
+  });
+  const stats = await webpackAsync(config);
+  const { errors } = stats.compilation;
+  assert.deepEqual(errors.length, 1);
+  const errorMessage = errors[0].message;
+  assert.match(
+    errorMessage,
+    /Error: Customized loaders must be passed as absolute paths, since babel-loader has no way to know what they would be relative to\./,
+  );
+});
+
+test("should warn when options.babelrc is a string", async () => {
+  const config = Object.assign({}, globalConfig, {
+    output: {
+      path: context.directory,
+    },
+    module: {
+      rules: [
+        {
+          test: /\.jsx?/,
+          loader: babelLoader,
+          exclude: /node_modules/,
+          options: {
+            babelrc: "./fixtures/babelrc",
+          },
+        },
+      ],
+    },
+  });
+  const stats = await webpackAsync(config);
+  const { warnings } = stats.compilation;
+  assert.deepEqual(warnings.length, 1);
+  const warningMessage = warnings[0].message;
+  assert.match(
+    warningMessage,
+    /The option `babelrc` should not be set to a string anymore in the babel-loader config\./,
+  );
+});
+
+test("should warn when options.forceEnv is set", async () => {
+  const config = Object.assign({}, globalConfig, {
+    output: {
+      path: context.directory,
+    },
+    module: {
+      rules: [
+        {
+          test: /\.jsx?/,
+          loader: babelLoader,
+          exclude: /node_modules/,
+          options: {
+            forceEnv: "production",
+          },
+        },
+      ],
+    },
+  });
+  const stats = await webpackAsync(config);
+  const { warnings } = stats.compilation;
+  assert.deepEqual(warnings.length, 1);
+  const warningMessage = warnings[0].message;
+  assert.match(
+    warningMessage,
+    /The option `forceEnv` has been removed in favor of `envName` in Babel 7\./,
+  );
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -1647,7 +1647,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/json-schema@npm:*, @types/json-schema@npm:^7.0.8, @types/json-schema@npm:^7.0.9":
+"@types/json-schema@npm:*, @types/json-schema@npm:^7.0.8":
   version: 7.0.15
   resolution: "@types/json-schema@npm:7.0.15"
   checksum: 97ed0cb44d4070aecea772b7b2e2ed971e10c81ec87dd4ecc160322ffa55ff330dace1793489540e3e318d90942064bb697cc0f8989391797792d919737b3b98
@@ -1881,37 +1881,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ajv-formats@npm:^2.1.1":
-  version: 2.1.1
-  resolution: "ajv-formats@npm:2.1.1"
-  dependencies:
-    ajv: ^8.0.0
-  peerDependencies:
-    ajv: ^8.0.0
-  peerDependenciesMeta:
-    ajv:
-      optional: true
-  checksum: 4a287d937f1ebaad4683249a4c40c0fa3beed30d9ddc0adba04859026a622da0d317851316ea64b3680dc60f5c3c708105ddd5d5db8fe595d9d0207fd19f90b7
-  languageName: node
-  linkType: hard
-
 "ajv-keywords@npm:^3.5.2":
   version: 3.5.2
   resolution: "ajv-keywords@npm:3.5.2"
   peerDependencies:
     ajv: ^6.9.1
   checksum: 7dc5e5931677a680589050f79dcbe1fefbb8fea38a955af03724229139175b433c63c68f7ae5f86cf8f65d55eb7c25f75a046723e2e58296707617ca690feae9
-  languageName: node
-  linkType: hard
-
-"ajv-keywords@npm:^5.1.0":
-  version: 5.1.0
-  resolution: "ajv-keywords@npm:5.1.0"
-  dependencies:
-    fast-deep-equal: ^3.1.3
-  peerDependencies:
-    ajv: ^8.8.2
-  checksum: c35193940b853119242c6757787f09ecf89a2c19bcd36d03ed1a615e710d19d450cb448bfda407b939aba54b002368c8bff30529cc50a0536a8e10bcce300421
   languageName: node
   linkType: hard
 
@@ -1924,18 +1899,6 @@ __metadata:
     json-schema-traverse: ^0.4.1
     uri-js: ^4.2.2
   checksum: 874972efe5c4202ab0a68379481fbd3d1b5d0a7bd6d3cc21d40d3536ebff3352a2a1fabb632d4fd2cc7fe4cbdcd5ed6782084c9bbf7f32a1536d18f9da5007d4
-  languageName: node
-  linkType: hard
-
-"ajv@npm:^8.0.0, ajv@npm:^8.9.0":
-  version: 8.16.0
-  resolution: "ajv@npm:8.16.0"
-  dependencies:
-    fast-deep-equal: ^3.1.3
-    json-schema-traverse: ^1.0.0
-    require-from-string: ^2.0.2
-    uri-js: ^4.4.1
-  checksum: bdf3d4c9f1d11e220850051ef4cd89346e951cfb933d6d41be36d45053c1092af1523ee6c62525cce567355caf0a4f4c19a08a93851649c1fa32b4a39b7c4858
   languageName: node
   linkType: hard
 
@@ -2021,7 +1984,6 @@ __metadata:
     husky: ^8.0.3
     lint-staged: ^13.2.3
     prettier: ^3.0.0
-    schema-utils: ^4.0.0
     webpack: ^5.93.0
   peerDependencies:
     "@babel/core": ^7.12.0
@@ -3337,13 +3299,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"json-schema-traverse@npm:^1.0.0":
-  version: 1.0.0
-  resolution: "json-schema-traverse@npm:1.0.0"
-  checksum: 02f2f466cdb0362558b2f1fd5e15cce82ef55d60cd7f8fa828cf35ba74330f8d767fcae5c5c2adb7851fa811766c694b9405810879bc4e1ddd78a7c0e03658ad
-  languageName: node
-  linkType: hard
-
 "json-stable-stringify-without-jsonify@npm:^1.0.1":
   version: 1.0.1
   resolution: "json-stable-stringify-without-jsonify@npm:1.0.1"
@@ -4087,13 +4042,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"require-from-string@npm:^2.0.2":
-  version: 2.0.2
-  resolution: "require-from-string@npm:2.0.2"
-  checksum: a03ef6895445f33a4015300c426699bc66b2b044ba7b670aa238610381b56d3f07c686251740d575e22f4c87531ba662d06937508f0f3c0f1ddc04db3130560b
-  languageName: node
-  linkType: hard
-
 "resolve-from@npm:^4.0.0":
   version: 4.0.0
   resolution: "resolve-from@npm:4.0.0"
@@ -4200,18 +4148,6 @@ __metadata:
     ajv: ^6.12.5
     ajv-keywords: ^3.5.2
   checksum: ea56971926fac2487f0757da939a871388891bc87c6a82220d125d587b388f1704788f3706e7f63a7b70e49fc2db974c41343528caea60444afd5ce0fe4b85c0
-  languageName: node
-  linkType: hard
-
-"schema-utils@npm:^4.0.0":
-  version: 4.2.0
-  resolution: "schema-utils@npm:4.2.0"
-  dependencies:
-    "@types/json-schema": ^7.0.9
-    ajv: ^8.9.0
-    ajv-formats: ^2.1.1
-    ajv-keywords: ^5.1.0
-  checksum: 26a0463d47683258106e6652e9aeb0823bf0b85843039e068b57da1892f7ae6b6b1094d48e9ed5ba5cbe9f7166469d880858b9d91abe8bd249421eb813850cde
   languageName: node
   linkType: hard
 
@@ -4648,7 +4584,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"uri-js@npm:^4.2.2, uri-js@npm:^4.4.1":
+"uri-js@npm:^4.2.2":
   version: 4.4.1
   resolution: "uri-js@npm:4.4.1"
   dependencies:


### PR DESCRIPTION
**Please Read the [CONTRIBUTING Guidelines](https://github.com/babel/babel-loader/blob/main/CONTRIBUTING.md)**
*In particular the portion on Commit Message Formatting*

**Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:


**Other information**:
Use webpack builtin schema validation utils and remove `schema-utils` from dependencies. The `schema-utils` is a dependency of `webpack` anyway.

Also added a few tests for options validation.