### PR TITLE
Support cache with external dependencies

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -1,2 +1,3 @@
+enableGlobalCache: true
 nodeLinker: node-modules
 yarnPath: .yarn/releases/yarn-3.6.4.cjs

--- a/src/cache.js
+++ b/src/cache.js
@@ -65,10 +65,7 @@ const filename = function (source, identifier, options, hash) {
   return hash.digest("hex") + ".json";
 };
 
-const handleExternalDepedencies = async function (
-  externalDependencies,
-  getFileTimestamp,
-) {
+const addTimestamps = async function (externalDependencies, getFileTimestamp) {
   for (const depAndEmptyTimestamp of externalDependencies) {
     try {
       const [dep] = depAndEmptyTimestamp;
@@ -78,7 +75,6 @@ const handleExternalDepedencies = async function (
       // ignore errors if timestamp is not available
     }
   }
-  return externalDependencies;
 };
 
 const areExternalDependenciesModified = async function (
@@ -156,10 +152,7 @@ const handleCache = async function (directory, params) {
   // Otherwise just transform the file
   // return it to the user asap and write it in cache
   const result = await transform(source, options);
-  result.externalDependencies = await handleExternalDepedencies(
-    result.externalDependencies,
-    getFileTimestamp,
-  );
+  await addTimestamps(result.externalDependencies, getFileTimestamp);
 
   try {
     await write(file, cacheCompression, result);

--- a/src/cache.js
+++ b/src/cache.js
@@ -91,7 +91,7 @@ const areExternalDependenciesModified = async function (
     let newTimestamp;
     try {
       newTimestamp = (await getFileTimestamp(dep)).timestamp + "";
-    } catch (err) {
+    } catch {
       return true;
     }
     if (timestamp !== newTimestamp) {

--- a/src/cache.js
+++ b/src/cache.js
@@ -69,17 +69,16 @@ const handleExternalDepedencies = async function (
   externalDependencies,
   getFileTimestamp,
 ) {
-  const result = [];
-  for (const dep of externalDependencies) {
+  for (const depAndEmptyTimestamp of externalDependencies) {
     try {
+      const [dep] = depAndEmptyTimestamp;
       const { timestamp } = await getFileTimestamp(dep);
-      result.push(dep + "\0" + timestamp);
+      depAndEmptyTimestamp.push(timestamp);
     } catch {
-      result.push(dep);
+      // ignore errors if timestamp is not available
     }
   }
-  result.sort();
-  return result;
+  return externalDependencies;
 };
 
 const areExternalDependenciesModified = async function (
@@ -87,10 +86,10 @@ const areExternalDependenciesModified = async function (
   getFileTimestamp,
 ) {
   for (const depAndTimestamp of externalDepsWithTimestamp) {
-    const [dep, timestamp] = depAndTimestamp.split("\0");
+    const [dep, timestamp] = depAndTimestamp;
     let newTimestamp;
     try {
-      newTimestamp = (await getFileTimestamp(dep)).timestamp + "";
+      newTimestamp = (await getFileTimestamp(dep)).timestamp;
     } catch {
       return true;
     }

--- a/src/index.js
+++ b/src/index.js
@@ -176,10 +176,10 @@ async function loader(source, inputSourceMap, overrides) {
     } = loaderOptions;
 
     let result;
-    const getFileTimestamp = promisify((path, cb) => {
-      this._compilation.fileSystemInfo.getFileTimestamp(path, cb);
-    });
     if (cacheDirectory) {
+      const getFileTimestamp = promisify((path, cb) => {
+        this._compilation.fileSystemInfo.getFileTimestamp(path, cb);
+      });
       const hash = this.utils.createHash(
         this._compilation.outputOptions.hashFunction,
       );

--- a/src/index.js
+++ b/src/index.js
@@ -212,8 +212,7 @@ async function loader(source, inputSourceMap, overrides) {
 
       const { code, map, metadata, externalDependencies } = result;
 
-      externalDependencies?.forEach(depAndTimestamp => {
-        const dep = depAndTimestamp.split("\0")[0];
+      externalDependencies?.forEach(([dep]) => {
         this.addDependency(dep);
       });
       metadataSubscribers.forEach(subscriber => {

--- a/src/transform.js
+++ b/src/transform.js
@@ -32,7 +32,9 @@ module.exports = async function (source, options) {
     metadata,
     sourceType,
     // Convert it from a Set to an Array to make it JSON-serializable.
-    externalDependencies: Array.from(externalDependencies || []),
+    externalDependencies: Array.from(externalDependencies || [], dep => [
+      dep,
+    ]).sort(),
   };
 };
 

--- a/src/transform.js
+++ b/src/transform.js
@@ -16,7 +16,7 @@ module.exports = async function (source, options) {
 
   // We don't return the full result here because some entries are not
   // really serializable. For a full list of properties see here:
-  // https://github.com/babel/babel/blob/main/packages/babel-core/src/transformation/index.js
+  // https://github.com/babel/babel/blob/main/packages/babel-core/src/transformation/index.ts
   // For discussion on this topic see here:
   // https://github.com/babel/babel-loader/pull/629
   const { ast, code, map, metadata, sourceType, externalDependencies } = result;

--- a/test/cache.test.js
+++ b/test/cache.test.js
@@ -333,3 +333,90 @@ test("should allow to specify the .babelrc file", async () => {
   // is { "presets": ["@babel/preset-env"] }
   assert.ok(files.length === 1);
 });
+
+test.cb("should cache external dependencies", t => {
+  const dep = path.join(cacheDir, "externalDependency.txt");
+
+  fs.writeFileSync(dep, "123");
+
+  let counter = 0;
+
+  const config = Object.assign({}, globalConfig, {
+    entry: path.join(__dirname, "fixtures/constant.js"),
+    output: {
+      path: t.context.directory,
+    },
+    module: {
+      rules: [
+        {
+          test: /\.js$/,
+          loader: babelLoader,
+          options: {
+            babelrc: false,
+            configFile: false,
+            cacheDirectory: t.context.cacheDirectory,
+            plugins: [
+              api => {
+                api.cache.never();
+                api.addExternalDependency(dep);
+                return {
+                  visitor: {
+                    BooleanLiteral(path) {
+                      counter++;
+                      path.replaceWith(
+                        api.types.stringLiteral(fs.readFileSync(dep, "utf8")),
+                      );
+                      path.stop();
+                    },
+                  },
+                };
+              },
+            ],
+          },
+        },
+      ],
+    },
+  });
+
+  webpack(config, (err, stats) => {
+    t.deepEqual(stats.compilation.warnings, []);
+    t.deepEqual(stats.compilation.errors, []);
+
+    t.true(stats.compilation.fileDependencies.has(dep));
+
+    t.is(counter, 1);
+
+    webpack(config, (err, stats) => {
+      t.deepEqual(stats.compilation.warnings, []);
+      t.deepEqual(stats.compilation.errors, []);
+
+      t.true(stats.compilation.fileDependencies.has(dep));
+
+      t.is(counter, 2);
+
+      webpack(config, (err, stats) => {
+        t.deepEqual(stats.compilation.warnings, []);
+        t.deepEqual(stats.compilation.errors, []);
+
+        t.true(stats.compilation.fileDependencies.has(dep));
+
+        t.is(counter, 2);
+
+        fs.writeFileSync(dep, "456");
+
+        setTimeout(() => {
+          webpack(config, (err, stats) => {
+            t.deepEqual(stats.compilation.warnings, []);
+            t.deepEqual(stats.compilation.errors, []);
+
+            t.true(stats.compilation.fileDependencies.has(dep));
+
+            t.is(counter, 3);
+
+            t.end();
+          });
+        }, 1000);
+      });
+    });
+  });
+});


### PR DESCRIPTION
**Please Read the [CONTRIBUTING Guidelines](https://github.com/babel/babel-loader/blob/main/CONTRIBUTING.md)**
*In particular the portion on Commit Message Formatting*

**Please check if the PR fulfills these requirements**
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)
The babel-loader cache is disabled when there are external dependencies registered from the Babel plugin API `addExternalDependencies`


**What is the new behavior?**
Still enable the cache if there are external deps. When the external deps are modified, the cache will be disgarded.


**Does this PR introduce a breaking change?**
- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the following...

* Impact:
* Migration path for existing applications:
* Github Issue(s) this is regarding:


**Other information**:
This PR is reviving #984, it picks the tests from #984 but adopts a slightly different approach.

In #984 we generate timestamps and use that as a cache identifier. As is pointed out in https://github.com/babel/babel-loader/pull/984#discussion_r1146670461, the cache will not be reused after the first run because of different cache identifiers (One for unknown externalDeps and the other for known externalDepsMtimes).

In this PR we store the timestamps of external deps within the transform result and validate it against the new timestamps returned from the webpack API `_compilation.fileSystemInfo.getFileTimestamp`, so the first cache will be reused because there is no cache identifier changes as now we determine if the cache should be reused _after_ reading the cache result.

Closes #984, fixes #983.