### PR TITLE
Avoid error on missing getLogger (v8)

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -54,7 +54,10 @@ function makeLoader(callback) {
 
 async function loader(source, inputSourceMap, overrides) {
   const filename = this.resourcePath;
-  const logger = this.getLogger("babel-loader");
+  const logger =
+    typeof this.getLogger === "function"
+      ? this.getLogger("babel-loader")
+      : { debug: () => {} };
 
   let loaderOptions = loaderUtils.getOptions(this);
 


### PR DESCRIPTION
This PR has no tests and it's just a quick patch for https://github.com/babel/babel-loader/issues/1043, until when I have a proper fix and understand why getLoader is missing.